### PR TITLE
override type of hits.total based on track_total_hits

### DIFF
--- a/.changeset/cruel-ghosts-beam.md
+++ b/.changeset/cruel-ghosts-beam.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+improve types of hits.total and hits.hits[number].\_source based on the query

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ const output = await client.search(query);
 // And without having to add .search<Sources, Aggs>(query) everywhere, you now have access to the correct types
 const hits = output.hits.hits;
 for (const hit of hits) {
-    // Here hit is typed as { _source: { score: number; entity_id: string } | undefined }
-    const score = hit._source!.score; // typed as number
-    const entity_id = hit._source!.entity_id; // typed as string
-    const invalid = hit._source!.invalid; // error: Property 'invalid' does not exist on type '{ score: number; entity_id: string; }'
+    // Here hit is typed as { _source: { score: number; entity_id: string } }
+    const score = hit._source.score; // typed as number
+    const entity_id = hit._source.entity_id; // typed as string
+    const invalid = hit._source.invalid; // error: Property 'invalid' does not exist on type '{ score: number; entity_id: string; }'
 }
 
 
@@ -117,7 +117,6 @@ See more examples in the test files.
 - query fields and aggs fields are not typed.
 - aggs types are only types if we use `aggs`. You won't get types if you use `aggregations`.
 - Some agg functions might be missing.
-- Would be nice to have _source not be undefined if the query ask for fields.
 
 
 PRs are welcome to fix these limitations.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,12 @@ export type RequestedFields<
 export type RequestedIndex<Query extends BaseQuery> =
 	Query["index"] extends string ? Query["index"] : never;
 
+export type HasOption<
+	Query extends BaseQuery,
+	Option extends keyof Query,
+	V = unknown,
+> = Query[Option] extends V ? true : false;
+
 export type ExtractAggsKey<Query extends BaseQuery> =
 	Query[aggs] extends Record<infer K, unknown>
 		? K extends string
@@ -184,11 +190,23 @@ type BucketAggs<
 
 type ElasticsearchIndexes = Record<string, Record<string, unknown>>;
 
+type OverrideSearchResponse<Query extends BaseQuery, T, V> = Omit<
+	estypes.SearchResponse<T, V>,
+	"hits"
+> & {
+	hits: Omit<estypes.SearchHitsMetadata<T>, "total"> & {
+		total: HasOption<Query, "track_total_hits", false> extends true
+			? never
+			: NonNullable<estypes.SearchHitsMetadata<T>["total"]>;
+	};
+};
+
 export type ElasticsearchOutput<
 	Query extends BaseQuery,
 	E extends ElasticsearchIndexes,
 > = RequestedIndex<Query> extends keyof E
-	? estypes.SearchResponse<
+	? OverrideSearchResponse<
+			Query,
 			{
 				[K in RequestedFields<
 					Query,

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,16 +190,20 @@ type BucketAggs<
 
 type ElasticsearchIndexes = Record<string, Record<string, unknown>>;
 
-type OverrideSearchResponse<Query extends BaseQuery, T, V> = Omit<
-	estypes.SearchResponse<T, V>,
-	"hits"
-> & {
-	hits: Omit<estypes.SearchHitsMetadata<T>, "total"> & {
-		total: HasOption<Query, "track_total_hits", false> extends true
-			? never
-			: NonNullable<estypes.SearchHitsMetadata<T>["total"]>;
-	};
-};
+type OverrideSearchResponse<Query extends BaseQuery, T, V> = Prettify<
+	Omit<estypes.SearchResponse<T, V>, "hits"> & {
+		hits: Omit<estypes.SearchHitsMetadata<T>, "total" | "hits"> & {
+			total: HasOption<Query, "track_total_hits", false> extends true
+				? never
+				: NonNullable<estypes.SearchHitsMetadata<T>["total"]>;
+			hits: Array<
+				Omit<estypes.SearchHitsMetadata<T>["hits"][number], "_source"> & {
+					_source: Query["_source"] extends false ? never : T;
+				}
+			>;
+		};
+	}
+>;
 
 export type ElasticsearchOutput<
 	Query extends BaseQuery,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -71,6 +71,43 @@ describe("Elasticsearch Types Interface", () => {
 		>().toBeString();
 	});
 
+	describe("should enforce types based on options", () => {
+		describe("track_total_hits", () => {
+			test("set to true", () => {
+				const query = typedEs(client, {
+					index: "demo",
+					track_total_hits: true,
+					_source: false,
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<
+					number | estypes.SearchTotalHits
+				>();
+			});
+
+			test("set to false", () => {
+				const query = typedEs(client, {
+					index: "demo",
+					track_total_hits: false,
+					_source: false,
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<never>();
+			});
+
+			test("set to undefined", () => {
+				const query = typedEs(client, {
+					index: "demo",
+					_source: false,
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<
+					number | estypes.SearchTotalHits
+				>();
+			});
+		});
+	});
+
 	describe("typedEs", () => {
 		describe("Should enforce correct index", () => {
 			test("with valid index", () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -106,6 +106,35 @@ describe("Elasticsearch Types Interface", () => {
 				>();
 			});
 		});
+		describe("_source undefiend when set to false", () => {
+			test("false", () => {
+				const query = typedEs(client, {
+					index: "demo",
+					_source: false,
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				expectTypeOf<
+					Output["hits"]["hits"][0]["_source"]
+				>().toEqualTypeOf<never>();
+			});
+			test("undefined", () => {
+				const query = typedEs(client, {
+					index: "demo",
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				type Source = Output["hits"]["hits"][0]["_source"];
+				expectTypeOf<Source>().toEqualTypeOf<CustomIndexes["demo"]>();
+			});
+			test("empty array", () => {
+				const query = typedEs(client, {
+					index: "demo",
+					_source: [],
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				type Source = Output["hits"]["hits"][0]["_source"];
+				expectTypeOf<Source>().toEqualTypeOf<{}>();
+			});
+		});
 	});
 
 	describe("typedEs", () => {
@@ -159,45 +188,37 @@ describe("Elasticsearch Types Interface", () => {
 		describe("Should type the output", () => {
 			test("Should fail if the field is not found", () => {
 				expectTypeOf<
-					NonNullable<
-						ElasticsearchOutput<
-							typeof invalidSourceQuery,
-							CustomIndexes
-						>["hits"]["hits"][0]["_source"]
-					>["invalid"]
+					ElasticsearchOutput<
+						typeof invalidSourceQuery,
+						CustomIndexes
+					>["hits"]["hits"][0]["_source"]["invalid"]
 				>().toBeString();
 			});
 
 			describe("Should return the correct type", () => {
 				test("with _source", () => {
 					expectTypeOf<
-						NonNullable<
-							ElasticsearchOutput<
-								typeof invalidSourceQuery,
-								CustomIndexes
-							>["hits"]["hits"][0]["_source"]
-						>["score"]
+						ElasticsearchOutput<
+							typeof invalidSourceQuery,
+							CustomIndexes
+						>["hits"]["hits"][0]["_source"]["score"]
 					>().toEqualTypeOf<number>();
 				});
 				test("without _source", () => {
 					expectTypeOf<
-						NonNullable<
-							ElasticsearchOutput<
-								typeof queryWithoutSource,
-								CustomIndexes
-							>["hits"]["hits"][0]["_source"]
-						>
+						ElasticsearchOutput<
+							typeof queryWithoutSource,
+							CustomIndexes
+						>["hits"]["hits"][0]["_source"]
 					>().toEqualTypeOf<CustomIndexes["demo"]>();
 				});
 				test("with _source set to false", () => {
 					type Query = typeof queryWithoutSource & { _source: false };
 					expectTypeOf<
-						NonNullable<
-							ElasticsearchOutput<
-								Query,
-								CustomIndexes
-							>["hits"]["hits"][0]["_source"]
-						>
+						ElasticsearchOutput<
+							Query,
+							CustomIndexes
+						>["hits"]["hits"][0]["_source"]
 					>().toEqualTypeOf<{}>();
 				});
 			});
@@ -251,9 +272,7 @@ describe("Elasticsearch Types Interface", () => {
 						};
 					}>();
 
-					expectTypeOf<
-						NonNullable<Output["hits"]["hits"][0]["_source"]>
-					>().toEqualTypeOf<{
+					expectTypeOf<Output["hits"]["hits"][0]["_source"]>().toEqualTypeOf<{
 						score: number;
 					}>();
 				});
@@ -315,7 +334,7 @@ describe("Elasticsearch Types Interface", () => {
 				}>();
 
 				expectTypeOf<
-					NonNullable<Output["hits"]["hits"][0]["_source"]>
+					Output["hits"]["hits"][0]["_source"]
 				>().toEqualTypeOf<{}>();
 			});
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -219,7 +219,7 @@ describe("Elasticsearch Types Interface", () => {
 							Query,
 							CustomIndexes
 						>["hits"]["hits"][0]["_source"]
-					>().toEqualTypeOf<{}>();
+					>().toEqualTypeOf<never>();
 				});
 			});
 
@@ -332,10 +332,6 @@ describe("Elasticsearch Types Interface", () => {
 						}>;
 					};
 				}>();
-
-				expectTypeOf<
-					Output["hits"]["hits"][0]["_source"]
-				>().toEqualTypeOf<{}>();
 			});
 
 			test("number agg on a non-number field", () => {


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated example code to reflect improved type safety for Elasticsearch query results, including clearer handling of the `_source` property and minor formatting cleanup.

* **New Features**
  * Enhanced TypeScript typings for query results, providing more accurate types for `hits.total` and `hits.hits[number]._source` based on query options.

* **Tests**
  * Added and refined tests to validate the new conditional typings for query result properties, ensuring correct type enforcement based on query options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->