### PR TITLE
fix: `aggregations` key is correctly parsed for aggregations

### DIFF
--- a/.changeset/petite-signs-rhyme.md
+++ b/.changeset/petite-signs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+handle `aggregations` as aggregation key (previously only `aggs`)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ See more examples in the test files.
 
 - _source error message is not very clear when a field is invalid.
 - query fields and aggs fields are not typed.
-- aggs types are only types if we use `aggs`. You won't get types if you use `aggregations`.
 - Some agg functions might be missing.
 
 

--- a/biome.json
+++ b/biome.json
@@ -20,6 +20,9 @@
 			"recommended": true,
 			"complexity": {
 				"noBannedTypes": "off"
+			},
+			"suspicious": {
+				"noRedeclare": "off"
 			}
 		}
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,13 +241,9 @@ export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 		};
 	}[keyof Indexes];
 
-type ExtractAggs<V> = V extends {
-	aggs: infer A;
-}
+type ExtractAggs<V> = V extends { aggs: infer A } | { aggregations: infer A }
 	? A
-	: V extends { aggregations: infer A }
-		? A
-		: never;
+	: never;
 
 type Prettify<T> = {
 	[K in keyof T]: T[K];

--- a/tests/output/aggregations/composite.test.ts
+++ b/tests/output/aggregations/composite.test.ts
@@ -10,7 +10,7 @@ describe("Composite Aggregations", () => {
 			size: 10,
 			from: 0,
 			_source: ["score"],
-			aggs: {
+			aggregations: {
 				page: {
 					composite: {
 						size: 10,

--- a/tests/output/aggregations/date-histogram.test.ts
+++ b/tests/output/aggregations/date-histogram.test.ts
@@ -15,7 +15,7 @@ describe("Date Histogram Aggregations", () => {
 						field: "@timestamp",
 						calendar_interval: "year",
 					},
-					aggs: {
+					aggregations: {
 						daily: {
 							date_histogram: {
 								field: "@timestamp",


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/4

@coderabbit summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for queries using either aggs or aggregations as the key for aggregations, enhancing flexibility.

* **Documentation**
  * Updated the README to remove a statement about type limitations related to aggs and aggregations.

* **Tests**
  * Updated tests to use aggregations as the key in query objects, ensuring compatibility with the new flexible aggregation key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->