### PR TITLE
handle rest_total_hits_as_int

### DIFF
--- a/.changeset/hungry-parrots-sell.md
+++ b/.changeset/hungry-parrots-sell.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+handle `rest_total_hits_as_int` option

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,9 @@ type OverrideSearchResponse<Query extends BaseQuery, T, V> = Prettify<
 		hits: Omit<estypes.SearchHitsMetadata<T>, "total" | "hits"> & {
 			total: HasOption<Query, "track_total_hits", false> extends true
 				? never
-				: NonNullable<estypes.SearchHitsMetadata<T>["total"]>;
+				: HasOption<Query, "rest_total_hits_as_int", true> extends true
+					? number
+					: estypes.SearchTotalHits;
 			hits: Array<
 				Omit<estypes.SearchHitsMetadata<T>["hits"][number], "_source"> & {
 					_source: Query["_source"] extends false ? never : T;
@@ -219,7 +221,9 @@ export type ElasticsearchOutput<
 					E
 				>]: K extends keyof E[RequestedIndex<Query>]
 					? E[RequestedIndex<Query>][K]
-					: `Field '${K extends string ? K : "unknown"}' not found in index '${RequestedIndex<Query>}'`;
+					: `Field '${K extends string
+							? K
+							: "unknown"}' not found in index '${RequestedIndex<Query>}'`;
 			},
 			{
 				// @ts-expect-error: Query is BaseQuery not Record<string, unknown> but we know it

--- a/tests/query-options.test.ts
+++ b/tests/query-options.test.ts
@@ -13,11 +13,10 @@ describe("Query Options", () => {
 				_source: false,
 			});
 			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-			expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<
-				number | estypes.SearchTotalHits
-			>();
+			expectTypeOf<
+				Output["hits"]["total"]
+			>().toEqualTypeOf<estypes.SearchTotalHits>();
 		});
-
 		test("set to false", () => {
 			const query = typedEs(client, {
 				index: "demo",
@@ -34,9 +33,65 @@ describe("Query Options", () => {
 				_source: false,
 			});
 			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-			expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<
-				number | estypes.SearchTotalHits
-			>();
+			expectTypeOf<
+				Output["hits"]["total"]
+			>().toEqualTypeOf<estypes.SearchTotalHits>();
+		});
+	});
+
+	describe("rest_total_hits_as_int", () => {
+		test("set to true", () => {
+			const query = typedEs(client, {
+				index: "demo",
+				rest_total_hits_as_int: true,
+				_source: false,
+			});
+			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+			expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<number>();
+		});
+
+		test("set to false", () => {
+			const query = typedEs(client, {
+				index: "demo",
+				rest_total_hits_as_int: false,
+				_source: false,
+			});
+			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+			expectTypeOf<
+				Output["hits"]["total"]
+			>().toEqualTypeOf<estypes.SearchTotalHits>();
+		});
+
+		test("set to undefined (defaults to false)", () => {
+			const query = typedEs(client, {
+				index: "demo",
+				_source: false,
+			});
+			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+			expectTypeOf<
+				Output["hits"]["total"]
+			>().toEqualTypeOf<estypes.SearchTotalHits>();
+		});
+
+		test("combined with track_total_hits: false", () => {
+			const query = typedEs(client, {
+				index: "demo",
+				track_total_hits: false,
+				rest_total_hits_as_int: true,
+				_source: false,
+			});
+			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+			expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<never>();
+		});
+		test("combined with track_total_hits: true", () => {
+			const query = typedEs(client, {
+				index: "demo",
+				track_total_hits: true,
+				rest_total_hits_as_int: true,
+				_source: false,
+			});
+			type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+			expectTypeOf<Output["hits"]["total"]>().toEqualTypeOf<number>();
 		});
 	});
 


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the rest_total_hits_as_int option, ensuring correct typing for search response results.

* **Tests**
  * Added and updated tests to verify the behavior of the rest_total_hits_as_int and track_total_hits options in search responses.

* **Chores**
  * Updated documentation to reflect the patch addressing rest_total_hits_as_int handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->