### PR TITLE
reduce instanciations provocked by NextAggsParentKey

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -84,12 +84,10 @@ type ObjectKeysWithSpecificKeys<T, TargetKeys extends string> = {
 export type NextAggsParentKey<
 	Query extends Record<string, unknown>,
 	Aggs = ExtractAggs<Query>,
-> =
-	| ObjectKeysWithSpecificKeys<Aggs, "top_hits">
-	| ObjectKeysWithSpecificKeys<Aggs, "date_histogram">
-	| ObjectKeysWithSpecificKeys<Aggs, "terms">
-	| ObjectKeysWithSpecificKeys<Aggs, AggFunction>
-	| ObjectKeysWithSpecificKeys<Aggs, BucketAggFunction>;
+> = ObjectKeysWithSpecificKeys<
+	Aggs,
+	"top_hits" | "date_histogram" | "terms" | AggFunction | BucketAggFunction
+>;
 
 export type AggregationOutput<
 	BaseQuery extends SearchRequest,

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,7 +1,9 @@
 export type Prettify<T> = {
 	[K in keyof T]: T[K];
 } & {};
+
 export type PrettyArray<T> = Array<Prettify<T>>;
+
 export type UnionToIntersection<U> = (
 	U extends any
 		? (k: U) => void


### PR DESCRIPTION
improves https://github.com/Vahor/typed-es/issues/44

```
Lines of Library:            13054
Lines of Definitions:       158316
Lines of TypeScript:          1681
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                159693
Symbols:                    129012
Types:                       19169
Instantiations:             107152
Memory used:               211613K
Assignability cache size:     8425
Identity cache size:          1223
Subtype cache size:             49
Strict subtype cache size:     173
I/O Read time:               0.03s
Parse time:                  0.25s
ResolveModule time:          0.04s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.01s
Program time:                0.36s
Bind time:                   0.11s
Check time:                  0.28s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  0.75s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal type definitions to reduce repetition and improve readability. No changes to app behavior or user-facing features.

* **Style**
  * Improved code formatting for better clarity. No impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->