### PR TITLE
fix: top hits does not generate an array of hits

### DIFF
--- a/.changeset/many-poets-burn.md
+++ b/.changeset/many-poets-burn.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+fix `top_hits` agg output type

--- a/src/aggregations/top_hits.ts
+++ b/src/aggregations/top_hits.ts
@@ -15,7 +15,7 @@ export type TopHitsAggs<
 	top_hits: infer T extends Record<string, unknown>;
 }
 	? {
-			hits: PrettyArray<{
+			hits: {
 				total: QueryTotal<BaseQuery>;
 				max_score: number | null;
 				hits: PrettyArray<{
@@ -25,6 +25,6 @@ export type TopHitsAggs<
 					sort: Array<unknown>;
 					_score: number | null;
 				}>;
-			}>;
+			};
 		}
 	: never;

--- a/tests/aggregations/function.test.ts
+++ b/tests/aggregations/function.test.ts
@@ -108,7 +108,7 @@ describe("Leaf Function Aggregations", () => {
 						value: number;
 				  }
 				| {
-						hits: Array<{
+						hits: {
 							total: number;
 							max_score: number | null;
 							hits: Array<{
@@ -120,7 +120,7 @@ describe("Leaf Function Aggregations", () => {
 								sort: Array<unknown>;
 								_score: number | null;
 							}>;
-						}>;
+						};
 				  };
 		}>();
 	});

--- a/tests/aggregations/top-hits.test.ts
+++ b/tests/aggregations/top-hits.test.ts
@@ -46,7 +46,7 @@ describe("Top Hits Aggregations", () => {
 					key: unknown;
 					doc_count: number;
 					top_sales_hits: {
-						hits: Array<{
+						hits: {
 							total: number;
 							max_score: number | null;
 							hits: Array<{
@@ -60,7 +60,7 @@ describe("Top Hits Aggregations", () => {
 								sort: Array<unknown>;
 								_score: number | null;
 							}>;
-						}>;
+						};
 					};
 				}>;
 			};


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the output type of the `top_hits` aggregation to ensure the `hits` property is now a single object containing aggregation details instead of an array.
* **Tests**
  * Updated tests to reflect the new structure of the `hits` property in aggregation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->