### PR TITLE
add support for docvalue_fields

### DIFF
--- a/.changeset/khaki-teams-double.md
+++ b/.changeset/khaki-teams-double.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `docvalue_fields`

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ Automatically add output types to your Elasticsearch queries.
 
 ## Features
 - **Automatic type based on options**: Automatically infers output types from query options (e.g., returning `total` count).  
-- **Automatic output type based on requested fields and aggregations**: Derives precise types from specified `_source`, `fields` and `aggregations` configurations.  
+- **Automatic output type based on requested fields and aggregations**: Derives precise types from specified `_source`, `fields`, `docvalue_fields` and `aggregations` configurations.  
 - **Understand wildcards**: The library correctly detects and infers output types even when using wildcards in `_source`.  
   For example, given an index with fields `{ created_at: string; title: string }`,  
   specifying `_source: ["*_at"]` will correctly return `{ created_at: string }` in the output type.  
 
 ## Example Usage
 ```ts
-// Example: Using all features together
 type MyIndex = {
    "my-index": {
       id: number;
@@ -27,7 +26,7 @@ type MyIndex = {
 // Having to use `as unknown` is less than ideal, but as we're overriding types, typescript isn't very happy
 const client = new Client({/* config */}) as unknown as TypedClient<Indexes>;
 
-// Query with _source (wildcard), aggregation, and options
+// Query with _source (wildcard), fields, aggregation, and options
 const query = typedEs(client, {
 	index: "my-index",
 	_source: ["id", "na*"],

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -111,7 +111,11 @@ type OverrideSearchResponse<
 					"_source" | "fields"
 				> & {
 					_source: Query["_source"] extends false ? never : T_Source;
-					fields: "fields" extends keyof Query ? T_Fields : never;
+					fields: "fields" extends keyof Query
+						? T_Fields
+						: "docvalue_fields" extends keyof Query
+							? T_Fields
+							: never;
 				}
 			>;
 		};
@@ -170,7 +174,7 @@ type AnyString = string & {};
 
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 	SearchRequest,
-	"index" | "_source" | "fields"
+	"index" | "_source" | "fields" | "docvalue_fields"
 > &
 	{
 		[K in keyof Indexes]: {
@@ -185,6 +189,13 @@ export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 						exclude?: Array<PossibleFieldsWithWildcards<K, Indexes>>;
 				  };
 			fields?: Array<
+				| PossibleFieldsWithWildcards<K, Indexes>
+				| {
+						field: PossibleFieldsWithWildcards<K, Indexes>;
+						format?: string;
+				  }
+			>;
+			docvalue_fields?: Array<
 				| PossibleFieldsWithWildcards<K, Indexes>
 				| {
 						field: PossibleFieldsWithWildcards<K, Indexes>;

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -13,3 +13,8 @@ export type UnionToIntersection<U> = (
 	: never;
 
 export type IsNever<T> = [T] extends [never] ? true : false;
+
+export type GetField<
+	T extends Record<string, unknown>,
+	Key extends string,
+> = Key extends keyof T ? T[Key] : never;

--- a/src/types/requested-fields.ts
+++ b/src/types/requested-fields.ts
@@ -1,5 +1,5 @@
 import type { RequestedIndex } from "../lib";
-import type { IsNever } from "./helpers";
+import type { GetField, IsNever } from "./helpers";
 
 type InferSource<T, Key extends string> = T extends {
 	[k in Key]: (infer A)[];
@@ -35,7 +35,7 @@ export type ExtractQuery_Source<
 
 export type ExtractQueryFields<
 	Query extends Record<string, unknown>,
-	Fields = Query["fields"],
+	Fields = GetField<Query, "fields"> | GetField<Query, "docvalue_fields">,
 > = Fields extends readonly (infer FieldsItem extends
 	| string
 	| { field: string })[]

--- a/tests/elasticsearch-output.test.ts
+++ b/tests/elasticsearch-output.test.ts
@@ -210,6 +210,57 @@ describe("Should return the correct type", () => {
 				}>();
 			});
 		});
+
+		describe("docvalue_fields", () => {
+			test("with docvalue_fields", () => {
+				const query = typedEs(client, {
+					index: "orders",
+					_source: false,
+					docvalue_fields: ["shipping_address.street"],
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				type Hits = Output["hits"]["hits"][0];
+				expectTypeOf<Hits["fields"]>().toEqualTypeOf<{
+					"shipping_address.street": string[];
+				}>();
+			});
+
+			test("with docvalue_fields and _source", () => {
+				const query = typedEs(client, {
+					index: "orders",
+					_source: ["shipping_address.street"],
+					docvalue_fields: ["shipping_address.city"],
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				type Hits = Output["hits"]["hits"][0];
+				expectTypeOf<Hits["fields"]>().toEqualTypeOf<{
+					"shipping_address.city": string[];
+				}>();
+				expectTypeOf<Hits["_source"]>().toEqualTypeOf<{
+					shipping_address: {
+						street: string;
+					};
+				}>();
+			});
+
+			test("with docvalue_fields and fields and _source and wildcard", () => {
+				const query = typedEs(client, {
+					index: "orders",
+					_source: ["*_at"],
+					docvalue_fields: ["shipping_address.city"],
+					fields: ["shipping_address.street"],
+				});
+				type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+				type Hits = Output["hits"]["hits"][0];
+				expectTypeOf<Hits["fields"]>().toEqualTypeOf<{
+					"shipping_address.street": string[];
+					"shipping_address.city": string[];
+				}>();
+				expectTypeOf<Hits["_source"]>().toEqualTypeOf<{
+					created_at: string;
+				}>();
+			});
+		});
 	});
 
 	describe("aggregations", () => {

--- a/tests/field-extraction.test.ts
+++ b/tests/field-extraction.test.ts
@@ -5,11 +5,14 @@ import type {
 	RequestedIndex,
 	SearchRequest,
 } from "../src/index";
-import type { ExtractQuery_Source } from "../src/types/requested-fields";
+import type {
+	ExtractQuery_Source,
+	ExtractQueryFields,
+} from "../src/types/requested-fields";
 import type { CustomIndexes, testQueries } from "./shared";
 
 describe("Field Extraction", () => {
-	describe("Should extract the fields", () => {
+	describe("_source", () => {
 		test("with _source", () => {
 			const query = {
 				index: "demo",
@@ -78,15 +81,65 @@ describe("Field Extraction", () => {
 		});
 	});
 
-	test("Should extract the index", () => {
-		expectTypeOf<
-			RequestedIndex<typeof testQueries.invalidIndex>
-		>().toEqualTypeOf<"invalid">();
+	describe("fields", () => {
+		test("with fields", () => {
+			const query = {
+				index: "demo",
+				_source: false,
+				fields: ["sore", "invalid"],
+			} as const satisfies SearchRequest;
+			expectTypeOf<ExtractQueryFields<typeof query>>().toEqualTypeOf<
+				"sore" | "invalid"
+			>();
+		});
+
+		test("with object fields", () => {
+			const query = {
+				index: "demo",
+				_source: false,
+				fields: [{ field: "created_at", format: "yyyy-MM-dd" }],
+			} as const satisfies SearchRequest;
+			expectTypeOf<
+				ExtractQueryFields<typeof query>
+			>().toEqualTypeOf<"created_at">();
+		});
 	});
 
-	test("Should fail if the index is not found", () => {
-		expectTypeOf<
-			ElasticsearchOutput<typeof testQueries.invalidIndex, CustomIndexes>
-		>().toEqualTypeOf<"Index 'invalid' not found">;
+	describe("docvalue_fields", () => {
+		test("with docvalue_fields", () => {
+			const query = {
+				index: "demo",
+				_source: false,
+				docvalue_fields: ["sore", "invalid"],
+			} as const satisfies SearchRequest;
+			expectTypeOf<ExtractQueryFields<typeof query>>().toEqualTypeOf<
+				"sore" | "invalid"
+			>();
+		});
+
+		test("with object fields", () => {
+			const query = {
+				index: "demo",
+				_source: false,
+				docvalue_fields: [{ field: "created_at", format: "yyyy-MM-dd" }],
+			} as const satisfies SearchRequest;
+			expectTypeOf<
+				ExtractQueryFields<typeof query>
+			>().toEqualTypeOf<"created_at">();
+		});
+	});
+
+	describe("index", () => {
+		test("Should extract the index", () => {
+			expectTypeOf<
+				RequestedIndex<typeof testQueries.invalidIndex>
+			>().toEqualTypeOf<"invalid">();
+		});
+
+		test("Should fail if the index is not found", () => {
+			expectTypeOf<
+				ElasticsearchOutput<typeof testQueries.invalidIndex, CustomIndexes>
+			>().toEqualTypeOf<"Index 'invalid' not found">;
+		});
 	});
 });


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `docvalue_fields` feature, allowing more flexible handling and typing of Elasticsearch query results.

* **Documentation**
  * Updated documentation to clarify the inclusion and usage of `docvalue_fields` in output type inference and example queries.

* **Tests**
  * Introduced new and reorganized test cases to validate type inference and field extraction when using `docvalue_fields`, ensuring robust coverage for various query configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->