### PR TITLE
feat: add filters aggregation

### DIFF
--- a/.changeset/soft-cats-yawn.md
+++ b/.changeset/soft-cats-yawn.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `filters` aggregation based on https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filters-aggregation.

--- a/src/aggregations/filters.ts
+++ b/src/aggregations/filters.ts
@@ -1,0 +1,80 @@
+import type {
+	AggregationOutput,
+	ElasticsearchIndexes,
+	NextAggsParentKey,
+	SearchRequest,
+} from "..";
+import type { Prettify, PrettyArray } from "../types/helpers";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filters-aggregation
+
+type KeysAndOBK<Keys, Agg> = Agg extends {
+	filters: { other_bucket_key: infer OBK extends string };
+}
+	? OBK | Keys
+	: Keys;
+
+export type FiltersAggs<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	filters: {
+		keyed?: infer Keyed;
+		filters: infer Filters;
+	};
+}
+	? Filters extends Array<unknown>
+		? // Anonymous filters (array format)
+			{
+				buckets: PrettyArray<
+					{
+						doc_count: number;
+					} & {
+						[k in NextAggsParentKey<Agg>]: AggregationOutput<
+							BaseQuery,
+							Agg,
+							E,
+							k,
+							Index
+						>;
+					}
+				>;
+			}
+		: Filters extends Record<infer Keys, unknown>
+			? // Named filters (object format)
+				Keyed extends false
+				? {
+						buckets: PrettyArray<
+							{
+								key: KeysAndOBK<Keys, Agg>;
+								doc_count: number;
+							} & {
+								[k in NextAggsParentKey<Agg>]: AggregationOutput<
+									BaseQuery,
+									Agg,
+									E,
+									k,
+									Index
+								>;
+							}
+						>;
+					}
+				: {
+						buckets: Prettify<{
+							[K in KeysAndOBK<Keys, Agg>]: {
+								doc_count: number;
+							} & {
+								[k in NextAggsParentKey<Agg>]: AggregationOutput<
+									BaseQuery,
+									Agg,
+									E,
+									k,
+									Index
+								>;
+							};
+						}>;
+					}
+			: never
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,6 +2,7 @@ import type { estypes } from "@elastic/elasticsearch";
 import type { BucketAggFunction, BucketAggs } from "./aggregations/bucket_agg";
 import type { CompositeAggs } from "./aggregations/composite";
 import type { DateHistogramAggs } from "./aggregations/date_histogram";
+import type { FiltersAggs } from "./aggregations/filters";
 import type { AggFunction, FunctionAggs } from "./aggregations/function";
 import type { ScriptedMetricAggs } from "./aggregations/scripted_metric";
 import type { TermsAggs } from "./aggregations/terms";
@@ -72,6 +73,7 @@ export type NextAggsParentKey<
 	Aggs,
 	| "top_hits"
 	| "date_histogram"
+	| "filters"
 	| "terms"
 	| "scripted_metric"
 	| "top_metrics"
@@ -91,6 +93,7 @@ export type AggregationOutput<
 	:
 			| CompositeAggs<BaseQuery, E, Index, Agg>
 			| DateHistogramAggs<BaseQuery, E, Index, Agg>
+			| FiltersAggs<BaseQuery, E, Index, Agg>
 			| TermsAggs<BaseQuery, E, Index, Agg>
 			| TopHitsAggs<BaseQuery, E, Index, Agg>
 			| FunctionAggs<E, Index, Agg>

--- a/tests/aggregations/filters.test.ts
+++ b/tests/aggregations/filters.test.ts
@@ -1,0 +1,165 @@
+import { describe, test } from "bun:test";
+import { type ElasticsearchOutput, typedEs } from "../../src/index";
+import { expectTypeOf } from "../helper";
+import { type CustomIndexes, client } from "../shared";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filters-aggregation
+describe("Filters Aggregations", () => {
+	test("with anonymous filters", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				messages: {
+					filters: {
+						filters: [
+							{ match: { body: "error" } },
+							{ match: { body: "warning" } },
+						],
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			messages: {
+				buckets: Array<{
+					doc_count: number;
+				}>;
+			};
+		}>();
+	});
+
+	test("with named filters", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				messages: {
+					filters: {
+						filters: {
+							errors: { match: { body: "error" } },
+							warnings: { match: { body: "warning" } },
+						},
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			messages: {
+				buckets: {
+					errors: {
+						doc_count: number;
+					};
+					warnings: {
+						doc_count: number;
+					};
+				};
+			};
+		}>();
+	});
+
+	test("with named filters and other_bucket_key", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				messages: {
+					filters: {
+						filters: {
+							warnings: { match: { body: "warning" } },
+						},
+						other_bucket_key: "another_key",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			messages: {
+				buckets: {
+					another_key: {
+						doc_count: number;
+					};
+					warnings: {
+						doc_count: number;
+					};
+				};
+			};
+		}>();
+	});
+
+	test("Should support `keyed` parameter", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				messages: {
+					filters: {
+						filters: {
+							errors: { match: { body: "error" } },
+							warnings: { match: { body: "warning" } },
+						},
+						other_bucket_key: "another_key",
+						keyed: false,
+					},
+				},
+			},
+		});
+
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			messages: {
+				buckets: Array<{
+					key: "errors" | "warnings" | "another_key";
+					doc_count: number;
+				}>;
+			};
+		}>();
+	});
+
+	test("Should support nested aggregations", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				the_filter: {
+					filters: {
+						keyed: false,
+						filters: {
+							"t-shirt": { term: { type: "t-shirt" } },
+							hat: { term: { type: "hat" } },
+						},
+					},
+					aggs: {
+						avg_price: { avg: { field: "price" } },
+						sort_by_avg_price: {
+							bucket_sort: { sort: { avg_price: "asc" } },
+						},
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			the_filter: {
+				buckets: Array<{
+					key: "t-shirt" | "hat";
+					doc_count: number;
+					avg_price: { value: number; value_as_string?: string };
+				}>;
+			};
+		}>();
+	});
+});

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -1,0 +1,7 @@
+export function expectTypeOf<T>() {
+	return {
+		toEqualTypeOf<_U extends T>() {
+			return;
+		},
+	};
+}


### PR DESCRIPTION
fix https://github.com/Vahor/typed-es/issues/69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Elasticsearch filters aggregation, enabling both anonymous and named filter configurations.
* **Tests**
  * Introduced comprehensive tests for filters aggregation, covering various scenarios including nested aggregations and keyed options.
  * Added a new type-checking helper for improved test assertions.
* **Chores**
  * Removed the dependency on `expect-types` in favor of a simpler internal implementation for type assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->