### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Vahor/typed-es/security/code-scanning/2](https://github.com/Vahor/typed-es/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/quality.yml`. The block should be placed at the root level (above `jobs:`) so that it applies to all jobs in the workflow, unless a job needs more specific permissions. For this workflow, the jobs only need to read repository contents, so the minimal permissions required are `contents: read`. No additional permissions are needed. This change does not affect the existing functionality of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
