### PR TITLE
add extended_stats agg support

### DIFF
--- a/.changeset/tough-ravens-cross.md
+++ b/.changeset/tough-ravens-cross.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `extended_stats` aggregation support

--- a/src/aggregations/extended_stats.ts
+++ b/src/aggregations/extended_stats.ts
@@ -1,0 +1,57 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+} from "..";
+
+export type ExtendedStatsAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	extended_stats: {
+		field: infer Field extends string;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? {
+				count: number;
+				min: number;
+				min_as_string?: string;
+				max: number;
+				max_as_string?: string;
+				avg: number;
+				avg_as_string?: string;
+				sum: number;
+				sum_as_string?: string;
+				sum_of_squares: number;
+				sum_of_squares_as_string?: string;
+				variance: number;
+				variance_as_string?: string;
+				variance_population: number;
+				variance_population_as_string?: string;
+				variance_sampling: number;
+				variance_sampling_as_string?: string;
+				std_deviation: number;
+				std_deviation_as_string?: string;
+				std_deviation_population: number;
+				std_deviation_population_as_string?: string;
+				std_deviation_sampling: number;
+				std_deviation_sampling_as_string?: string;
+				std_deviation_bounds: {
+					upper: number;
+					upper_as_string?: string;
+					lower: number;
+					lower_as_string?: string;
+					upper_population: number;
+					upper_population_as_string?: string;
+					lower_population: number;
+					lower_population_as_string?: string;
+					upper_sampling: number;
+					upper_sampling_as_string?: string;
+					lower_sampling: number;
+					lower_sampling_as_string?: string;
+				};
+			}
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,6 +3,7 @@ import type { BucketAggFunction, BucketAggs } from "./aggregations/bucket_agg";
 import type { CompositeAggs } from "./aggregations/composite";
 import type { DateHistogramAggs } from "./aggregations/date_histogram";
 import type { DateRangeAggs } from "./aggregations/date_range";
+import type { ExtendedStatsAggs } from "./aggregations/extended_stats";
 import type { FiltersAggs } from "./aggregations/filters";
 import type { AggFunction, FunctionAggs } from "./aggregations/function";
 import type { HistogramAggs } from "./aggregations/histogram";
@@ -79,7 +80,7 @@ export type InvalidFieldInAggregation<
 	Index extends string,
 	Aggregation,
 > = {
-	message: `Field '${Field}' cannot be used in aggregation on '${Index}'`;
+	error: `Field '${Field}' cannot be used in aggregation on '${Index}'`;
 	aggregation: Aggregation;
 };
 
@@ -137,6 +138,7 @@ export type NextAggsParentKey<
 	| "histogram"
 	| "date_range"
 	| "stats"
+	| "extended_stats"
 	| AggFunction
 	| BucketAggFunction
 >;
@@ -162,6 +164,7 @@ export type AggregationOutput<
 			| HistogramAggs<BaseQuery, E, Index, Agg>
 			| ScriptedMetricAggs<Agg>
 			| StatsAggs<E, Index, Agg>
+			| ExtendedStatsAggs<E, Index, Agg>
 			| TopMetricsAggs<E, Index, Agg>
 			| BucketAggs<Agg>;
 

--- a/tests/aggregations/extended_stats.test.ts
+++ b/tests/aggregations/extended_stats.test.ts
@@ -1,0 +1,91 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	typedEs,
+} from "../../src/index";
+import { type CustomIndexes, client } from "../shared";
+
+describe("Extended Stats Aggregations", () => {
+	test("with extended_stats on number field", () => {
+		const query = typedEs(client, {
+			index: "test_types",
+			size: 0,
+			_source: false,
+			aggs: {
+				price_stats: {
+					extended_stats: {
+						field: "price",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			price_stats: {
+				count: number;
+				min: number;
+				min_as_string?: string;
+				max: number;
+				max_as_string?: string;
+				avg: number;
+				avg_as_string?: string;
+				sum: number;
+				sum_as_string?: string;
+				sum_of_squares: number;
+				sum_of_squares_as_string?: string;
+				variance: number;
+				variance_as_string?: string;
+				variance_population: number;
+				variance_population_as_string?: string;
+				variance_sampling: number;
+				variance_sampling_as_string?: string;
+				std_deviation: number;
+				std_deviation_as_string?: string;
+				std_deviation_population: number;
+				std_deviation_population_as_string?: string;
+				std_deviation_sampling: number;
+				std_deviation_sampling_as_string?: string;
+				std_deviation_bounds: {
+					upper: number;
+					upper_as_string?: string;
+					lower: number;
+					lower_as_string?: string;
+					upper_population: number;
+					upper_population_as_string?: string;
+					lower_population: number;
+					lower_population_as_string?: string;
+					upper_sampling: number;
+					upper_sampling_as_string?: string;
+					lower_sampling: number;
+					lower_sampling_as_string?: string;
+				};
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				invalid_stats: {
+					extended_stats: {
+						field: "invalid_field",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldInAggregation<
+				"invalid_field",
+				"demo",
+				(typeof query)["aggs"]["invalid_stats"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/90

I'm not sure for all the `*_as_string` fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for extended_stats aggregation, including full metric outputs and deviation bounds.
- Refactor
  - Renamed the invalid-field aggregation error property from “message” to “error” for consistency.
- Tests
  - Added comprehensive type-level tests validating extended_stats outputs and invalid-field handling.
- Chores
  - Added changeset entry for a patch release announcing extended_stats aggregation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->