### PR TITLE
add geo_bounds support

### DIFF
--- a/.changeset/two-bats-fail.md
+++ b/.changeset/two-bats-fail.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `geo_bounds` aggregations.

--- a/src/aggregations/geo_bounds.ts
+++ b/src/aggregations/geo_bounds.ts
@@ -4,23 +4,29 @@ import type {
 	InvalidFieldInAggregation,
 } from "..";
 
-// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geocentroid-aggregation
-export type GeoCentroidAggs<
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geobounds-aggregation
+export type GeoBoundsAggs<
 	E extends ElasticsearchIndexes,
 	Index extends string,
 	Agg,
 > = Agg extends {
-	geo_centroid: {
+	geo_bounds: {
 		field: infer Field extends string;
+		wrap_longitude?: boolean;
 	};
 }
 	? CanBeUsedInAggregation<Field, Index, E> extends true
 		? {
-				location: {
-					lat: number;
-					lon: number;
+				bounds: {
+					top_left: {
+						lat: number;
+						lon: number;
+					};
+					bottom_right: {
+						lat: number;
+						lon: number;
+					};
 				};
-				count: number;
 			}
 		: InvalidFieldInAggregation<Field, Index, Agg>
 	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -6,6 +6,7 @@ import type { DateRangeAggs } from "./aggregations/date_range";
 import type { ExtendedStatsAggs } from "./aggregations/extended_stats";
 import type { FiltersAggs } from "./aggregations/filters";
 import type { AggFunction, FunctionAggs } from "./aggregations/function";
+import type { GeoBoundsAggs } from "./aggregations/geo_bounds";
 import type { GeoCentroidAggs } from "./aggregations/geo_centroid";
 import type { HistogramAggs } from "./aggregations/histogram";
 import type { RangeAggs } from "./aggregations/range";
@@ -141,6 +142,7 @@ export type NextAggsParentKey<
 	| "stats"
 	| "extended_stats"
 	| "geo_centroid"
+	| "geo_bounds"
 	| AggFunction
 	| BucketAggFunction
 >;
@@ -169,6 +171,7 @@ export type AggregationOutput<
 			| ExtendedStatsAggs<E, Index, Agg>
 			| TopMetricsAggs<E, Index, Agg>
 			| GeoCentroidAggs<E, Index, Agg>
+			| GeoBoundsAggs<E, Index, Agg>
 			| BucketAggs<Agg>;
 
 export type AppendSubAggs<

--- a/tests/aggregations/geo_bounds.test.ts
+++ b/tests/aggregations/geo_bounds.test.ts
@@ -1,0 +1,66 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	typedEs,
+} from "../../src/index";
+import { type CustomIndexes, client } from "../shared";
+
+describe("GeoBounds Aggregation", () => {
+	test("simple", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggs: {
+				viewport: {
+					geo_bounds: {
+						field: "shipping_address.geo_point",
+						wrap_longitude: true,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			viewport: {
+				bounds: {
+					top_left: {
+						lat: number;
+						lon: number;
+					};
+					bottom_right: {
+						lat: number;
+						lon: number;
+					};
+				};
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				viewport: {
+					geo_bounds: {
+						field: "invalid",
+						wrap_longitude: true,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			viewport: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				(typeof query)["aggs"]["viewport"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for geo_bounds aggregation, returning viewport bounds (top_left/bottom_right lat/lon) and recognizing wrap_longitude. Includes type-safe field validation against index schemas.
* **Documentation**
  * Added reference link for geo centroid aggregation.
* **Tests**
  * Introduced tests covering geo_bounds aggregation and invalid-field scenarios.
* **Chores**
  * Added changeset to publish a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->