### PR TITLE
add percentiles support

### DIFF
--- a/.changeset/swift-hoops-cross.md
+++ b/.changeset/swift-hoops-cross.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `percentiles` aggregations support.

--- a/src/aggregations/geo_line.ts
+++ b/src/aggregations/geo_line.ts
@@ -3,7 +3,6 @@ import type {
 	ElasticsearchIndexes,
 	InvalidFieldInAggregation,
 } from "..";
-import type { OrLowercase } from "../types/helpers";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geo-line
 export type GeoLineAggs<
@@ -16,12 +15,12 @@ export type GeoLineAggs<
 			field: infer Field extends string;
 		};
 		// Required only if not in a nested time_series aggregation. So optional for simplicity
-		sort?: {
-			field: string;
-		};
-		include_sort?: boolean;
-		size?: number;
-		sort_order?: OrLowercase<"ASC" | "DESC">;
+		// sort?: {
+		// 	field: string;
+		// };
+		// include_sort?: boolean;
+		// size?: number;
+		// sort_order?: OrLowercase<"ASC" | "DESC">;
 	};
 }
 	? CanBeUsedInAggregation<Field, Index, E> extends true

--- a/src/aggregations/percentiles.ts
+++ b/src/aggregations/percentiles.ts
@@ -1,0 +1,60 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
+} from "..";
+import type { IsSomeSortOf, ToDecimal } from "../types/helpers";
+
+type DefaultPercents = [1, 5, 25, 50, 75, 95, 99];
+
+type PercentilesValues<Percents extends readonly number[]> = {
+	[index in keyof Percents]: {
+		key: ToDecimal<Percents[index]>;
+		value: number;
+	};
+};
+
+type PercentilesValuesToObject<Values> = Values extends { key: string }[]
+	? {
+			[K in Values[number] as K["key"]]: number;
+		}
+	: never;
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-percentile-aggregation
+export type PercentilesAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	percentiles: {
+		field: infer Field extends string;
+		percents?: infer Percents;
+		keyed?: infer Keyed;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
+			? Keyed extends false
+				? {
+						values: PercentilesValues<
+							Percents extends number[] ? Percents : DefaultPercents
+						>;
+					}
+				: {
+						values: PercentilesValuesToObject<
+							PercentilesValues<
+								Percents extends number[] ? Percents : DefaultPercents
+							>
+						>;
+					}
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					number
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/aggregations/range.ts
+++ b/src/aggregations/range.ts
@@ -5,26 +5,18 @@ import type {
 	InvalidFieldInAggregation,
 	SearchRequest,
 } from "..";
-import type {
-	IsFloatLiteral,
-	IsNumericLiteral,
-	Prettify,
-} from "../types/helpers";
+import type { IsNever, Prettify, ToDecimal, ToString } from "../types/helpers";
 
 type RangeSpec = {
 	from?: number | undefined;
 	to?: number | undefined;
 };
 
-type ToString<T> = T extends number ? `${T}` : string;
-
-type FormatToKey<N> = IsFloatLiteral<N> extends true
-	? ToString<N>
-	: IsNumericLiteral<N> extends true
-		? `${ToString<N>}.0`
-		: undefined extends N
-			? "*"
-			: ToString<N>;
+type FormatToKey<N> = IsNever<ToDecimal<N>> extends false
+	? ToDecimal<N>
+	: undefined extends N
+		? "*"
+		: ToString<N>;
 
 type RangeOutput<
 	BaseQuery extends SearchRequest,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,7 @@ import type { GeoBoundsAggs } from "./aggregations/geo_bounds";
 import type { GeoCentroidAggs } from "./aggregations/geo_centroid";
 import type { GeoLineAggs } from "./aggregations/geo_line";
 import type { HistogramAggs } from "./aggregations/histogram";
+import type { PercentilesAggs } from "./aggregations/percentiles";
 import type { RangeAggs } from "./aggregations/range";
 import type { ScriptedMetricAggs } from "./aggregations/scripted_metric";
 import type { StatsAggs } from "./aggregations/stats";
@@ -21,6 +22,7 @@ import type {
 	IsNever,
 	IsStringLiteral,
 	Prettify,
+	ToString,
 	UnionToIntersection,
 } from "./types/helpers";
 import type {
@@ -87,6 +89,19 @@ export type InvalidFieldInAggregation<
 	aggregation: Aggregation;
 };
 
+export type InvalidFieldTypeInAggregation<
+	Field extends string,
+	Index extends string,
+	Aggregation,
+	got,
+	expected,
+> = {
+	error: `Field '${Field}' cannot be used in aggregation on '${Index}' because it is of type '${ToString<got>}' but expected '${ToString<expected>}'`;
+	aggregation: Aggregation;
+	got: got;
+	expected: expected;
+};
+
 export type PossibleFieldsWithWildcards<
 	Index,
 	Indexes extends ElasticsearchIndexes,
@@ -145,6 +160,7 @@ export type NextAggsParentKey<
 	| "geo_centroid"
 	| "geo_bounds"
 	| "geo_line"
+	| "percentiles"
 	| AggFunction
 	| BucketAggFunction
 >;
@@ -175,6 +191,7 @@ export type AggregationOutput<
 			| GeoCentroidAggs<E, Index, Agg>
 			| GeoBoundsAggs<E, Index, Agg>
 			| GeoLineAggs<E, Index, Agg>
+			| PercentilesAggs<E, Index, Agg>
 			| BucketAggs<Agg>;
 
 export type AppendSubAggs<

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -42,3 +42,27 @@ export type IsStringLiteral<T> = T extends string
 export type AnyString = string & {};
 
 export type OrLowercase<T extends string> = Lowercase<T> | T;
+
+export type ToString<T> = T extends string | number | boolean | undefined | null
+	? `${T}`
+	: T extends Function
+		? "function"
+		: T extends Array<any>
+			? `Array`
+			: T extends object
+				? "object"
+				: T extends any
+					? "any"
+					: "unknown";
+
+export type IsSomeSortOf<T, U> = T extends U
+	? true
+	: U extends T
+		? true
+		: false;
+
+export type ToDecimal<N> = IsFloatLiteral<N> extends true
+	? ToString<N>
+	: IsNumericLiteral<N> extends true
+		? `${ToString<N>}.0`
+		: never;

--- a/tests/aggregations/percentiles.test.ts
+++ b/tests/aggregations/percentiles.test.ts
@@ -1,0 +1,170 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	type InvalidFieldTypeInAggregation,
+	typedEs,
+} from "../../src/index";
+import { type CustomIndexes, client } from "../shared";
+
+describe("Percentiles Aggregation", () => {
+	test("simple", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggs: {
+				load_time_outlier: {
+					percentiles: {
+						field: "total",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_outlier: {
+				values: {
+					"1.0": number;
+					"5.0": number;
+					"25.0": number;
+					"50.0": number;
+					"75.0": number;
+					"95.0": number;
+					"99.0": number;
+				};
+			};
+		}>();
+	});
+
+	test("with custom percents", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggs: {
+				load_time_outlier: {
+					percentiles: {
+						field: "total",
+						percents: [95, 99, 99.9],
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_outlier: {
+				values: {
+					"95.0": number;
+					"99.0": number;
+					"99.9": number;
+				};
+			};
+		}>();
+	});
+
+	test("with keyed=false", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			_source: false,
+			size: 0,
+			aggs: {
+				load_time_outlier: {
+					percentiles: {
+						field: "total.some_format",
+						keyed: false,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_outlier: {
+				values: [
+					{
+						key: "1.0";
+						value: number;
+					},
+					{
+						key: "5.0";
+						value: number;
+					},
+					{
+						key: "25.0";
+						value: number;
+					},
+					{
+						key: "50.0";
+						value: number;
+					},
+					{
+						key: "75.0";
+						value: number;
+					},
+					{
+						key: "95.0";
+						value: number;
+					},
+					{
+						key: "99.0";
+						value: number;
+					},
+				];
+			};
+		}>();
+	});
+
+	test("fails when using an invalid type field", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			_source: false,
+			size: 0,
+			aggs: {
+				load_time_outlier: {
+					percentiles: {
+						field: "id",
+						keyed: false,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_outlier: InvalidFieldTypeInAggregation<
+				"id",
+				"orders",
+				(typeof query)["aggs"]["load_time_outlier"],
+				string,
+				number
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				load_time_outlier: {
+					percentiles: {
+						field: "invalid",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_outlier: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				(typeof query)["aggs"]["load_time_outlier"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added percentiles aggregation support with default percentiles and keyed/array outputs.
- Refactor
  - Standardized range aggregation bucket keys to consistent decimal string formatting.
  - Removed sorting options from GeoLine aggregation for a simplified configuration.
- Tests
  - Added comprehensive tests covering percentiles aggregation, custom percents, keyed behavior, and validation errors.
- Chores
  - Added changeset entry for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->