### PR TITLE
add support for percentile_ranks

### DIFF
--- a/.changeset/old-jobs-smoke.md
+++ b/.changeset/old-jobs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `percentile_ranks` aggregation.

--- a/src/aggregations/percentile_ranks.ts
+++ b/src/aggregations/percentile_ranks.ts
@@ -1,0 +1,52 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
+} from "..";
+import type { IsSomeSortOf, ToDecimal } from "../types/helpers";
+
+type PercentilesValues<Percents extends readonly number[]> = {
+	[index in keyof Percents]: {
+		key: ToDecimal<Percents[index]>;
+		value: number;
+	};
+};
+
+type PercentilesValuesToObject<Values> = Values extends { key: string }[]
+	? {
+			[K in Values[number] as K["key"]]: number;
+		}
+	: never;
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-percentile-rank-aggregation
+export type PercentileRanksAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	percentile_ranks: {
+		field: infer Field extends string;
+		values: infer Values extends number[];
+		keyed?: infer Keyed;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
+			? Keyed extends false
+				? {
+						values: PercentilesValues<Values>;
+					}
+				: {
+						values: PercentilesValuesToObject<PercentilesValues<Values>>;
+					}
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					number
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,7 @@ import type { GeoBoundsAggs } from "./aggregations/geo_bounds";
 import type { GeoCentroidAggs } from "./aggregations/geo_centroid";
 import type { GeoLineAggs } from "./aggregations/geo_line";
 import type { HistogramAggs } from "./aggregations/histogram";
+import type { PercentileRanksAggs } from "./aggregations/percentile_ranks";
 import type { PercentilesAggs } from "./aggregations/percentiles";
 import type { RangeAggs } from "./aggregations/range";
 import type { ScriptedMetricAggs } from "./aggregations/scripted_metric";
@@ -161,6 +162,7 @@ export type NextAggsParentKey<
 	| "geo_bounds"
 	| "geo_line"
 	| "percentiles"
+	| "percentile_ranks"
 	| AggFunction
 	| BucketAggFunction
 >;
@@ -192,6 +194,7 @@ export type AggregationOutput<
 			| GeoBoundsAggs<E, Index, Agg>
 			| GeoLineAggs<E, Index, Agg>
 			| PercentilesAggs<E, Index, Agg>
+			| PercentileRanksAggs<E, Index, Agg>
 			| BucketAggs<Agg>;
 
 export type AppendSubAggs<

--- a/tests/aggregations/percentile_ranks.test.ts
+++ b/tests/aggregations/percentile_ranks.test.ts
@@ -1,0 +1,121 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	type InvalidFieldTypeInAggregation,
+	typedEs,
+} from "../../src/index";
+import { type CustomIndexes, client } from "../shared";
+
+describe("PercentileRanks Aggregation", () => {
+	test("simple", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggs: {
+				load_time_ranks: {
+					percentile_ranks: {
+						field: "total",
+						values: [500, 600],
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_ranks: {
+				values: {
+					"500.0": number;
+					"600.0": number;
+				};
+			};
+		}>();
+	});
+
+	test("with keyed=false", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			_source: false,
+			size: 0,
+			aggs: {
+				load_time_ranks: {
+					percentile_ranks: {
+						field: "total",
+						values: [500, 600],
+						keyed: false,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_ranks: {
+				values: [
+					{
+						key: "500.0";
+						value: number;
+					},
+					{
+						key: "600.0";
+						value: number;
+					},
+				];
+			};
+		}>();
+	});
+
+	test("fails when using an invalid type field", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			_source: false,
+			size: 0,
+			aggs: {
+				load_time_ranks: {
+					percentile_ranks: {
+						field: "id",
+						values: [500, 600],
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_ranks: InvalidFieldTypeInAggregation<
+				"id",
+				"orders",
+				(typeof query)["aggs"]["load_time_ranks"],
+				string,
+				number
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				load_time_ranks: {
+					percentile_ranks: {
+						field: "invalid",
+						values: [500, 600],
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			load_time_ranks: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				(typeof query)["aggs"]["load_time_ranks"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for percentile_ranks aggregation with type-safe validation and outputs. Handles keyed and non-keyed results, ensuring fields are valid and numeric.
- Tests
  - Added comprehensive tests for percentile_ranks, covering successful scenarios and expected type errors for invalid fields or types.
- Chores
  - Added a patch release entry indicating the new percentile_ranks aggregation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->