### PR TITLE
Add support for `string_stats` aggregation.

### DIFF
--- a/.changeset/empty-cows-itch.md
+++ b/.changeset/empty-cows-itch.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `string_stats` aggregation.

--- a/src/aggregations/string_stats.ts
+++ b/src/aggregations/string_stats.ts
@@ -1,0 +1,44 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
+} from "..";
+import type { IsSomeSortOf, Prettify } from "../types/helpers";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-string-stats-aggregation
+export type StringStatsAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	string_stats: {
+		field: infer Field extends string;
+		show_distribution?: infer ShowDistribution;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
+			? Prettify<
+					{
+						count: number;
+						min_length: number;
+						max_length: number;
+						avg_length: number;
+						entropy: number;
+					} & {
+						[K in "distribution" as ShowDistribution extends true
+							? K
+							: never]: Record<string, number>;
+					}
+				>
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					string
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -16,6 +16,7 @@ import type { PercentilesAggs } from "./aggregations/percentiles";
 import type { RangeAggs } from "./aggregations/range";
 import type { ScriptedMetricAggs } from "./aggregations/scripted_metric";
 import type { StatsAggs } from "./aggregations/stats";
+import type { StringStatsAggs } from "./aggregations/string_stats";
 import type { TermsAggs } from "./aggregations/terms";
 import type { TopHitsAggs } from "./aggregations/top_hits";
 import type { TopMetricsAggs } from "./aggregations/top_metrics";
@@ -166,6 +167,7 @@ export type NextAggsParentKey<
 	| "percentiles"
 	| "percentile_ranks"
 	| "median_absolute_deviation"
+	| "string_stats"
 	| AggFunction
 	| BucketAggFunction
 >;
@@ -199,6 +201,7 @@ export type AggregationOutput<
 			| PercentilesAggs<E, Index, Agg>
 			| PercentileRanksAggs<E, Index, Agg>
 			| MedianAbsoluteDeviationAggs<E, Index, Agg>
+			| StringStatsAggs<E, Index, Agg>
 			| BucketAggs<Agg>;
 
 export type AppendSubAggs<

--- a/tests/aggregations/string_stats.test.ts
+++ b/tests/aggregations/string_stats.test.ts
@@ -1,0 +1,103 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	type InvalidFieldTypeInAggregation,
+	typedEs,
+} from "../../src/index";
+import { type CustomIndexes, client } from "../shared";
+
+describe("String Stats Aggregation", () => {
+	test("simple", () => {
+		const query = typedEs(client, {
+			index: "reviews",
+			size: 0,
+			_source: false,
+			aggs: {
+				rating_stats: {
+					string_stats: { field: "rating.string" },
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			rating_stats: {
+				count: number;
+				min_length: number;
+				max_length: number;
+				avg_length: number;
+				entropy: number;
+			};
+		}>();
+	});
+
+	test("with show_distribution", () => {
+		const query = typedEs(client, {
+			index: "reviews",
+			size: 0,
+			_source: false,
+			aggs: {
+				rating_stats: {
+					string_stats: { field: "rating.string", show_distribution: true },
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			rating_stats: {
+				count: number;
+				min_length: number;
+				max_length: number;
+				avg_length: number;
+				entropy: number;
+				distribution: Record<string, number>;
+			};
+		}>();
+	});
+
+	test("fails when using an invalid type field", () => {
+		const query = typedEs(client, {
+			index: "reviews",
+			_source: false,
+			size: 0,
+			aggs: {
+				rating_stats: { string_stats: { field: "rating" } },
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			rating_stats: InvalidFieldTypeInAggregation<
+				"rating",
+				"reviews",
+				(typeof query)["aggs"]["rating_stats"],
+				number,
+				string
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		const query = typedEs(client, {
+			index: "reviews",
+			_source: false,
+			size: 0,
+			aggs: {
+				invalid_stats: {
+					string_stats: { field: "invalid" },
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldInAggregation<
+				"invalid",
+				"reviews",
+				(typeof query)["aggs"]["invalid_stats"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the string_stats aggregation, including count, min_length, max_length, avg_length, and entropy, with an optional distribution output when enabled. Improved type inference and validation; no runtime changes.
- Tests
  - Added comprehensive tests for basic usage, distribution variant, and validation of invalid fields/types.
- Chores
  - Added a changeset entry documenting this patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->