### PR TITLE
add support for geohex_grid

### DIFF
--- a/.changeset/floppy-otters-turn.md
+++ b/.changeset/floppy-otters-turn.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `geohex_grid` bucket aggregation

--- a/src/aggregations/bucket/geohex_grid.ts
+++ b/src/aggregations/bucket/geohex_grid.ts
@@ -3,7 +3,7 @@ import type {
 	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
 	InvalidFieldInAggregation,
-	InvalidPropetyTypeInAggregation,
+	InvalidPropertyTypeInAggregation,
 	SearchRequest,
 } from "../..";
 import type {
@@ -38,6 +38,11 @@ export type GeoHexGridAggs<
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				}
-			: InvalidPropetyTypeInAggregation<"precision", Agg, Precision, Range_0_15>
+			: InvalidPropertyTypeInAggregation<
+					"precision",
+					Agg,
+					Precision,
+					Range_0_15
+				>
 		: InvalidFieldInAggregation<Field, Index, Agg>
 	: never;

--- a/src/aggregations/bucket/geohex_grid.ts
+++ b/src/aggregations/bucket/geohex_grid.ts
@@ -12,32 +12,32 @@ import type {
 	RangeInclusive,
 } from "../../types/helpers";
 
-type DefaultPrecision = 7;
+type DefaultPrecision = 6;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;
-type Range_0_29 = RangeInclusive<0, 29>;
+type Range_0_15 = RangeInclusive<0, 15>;
 
-// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-geotilegrid-aggregation
-export type GeoTileGridAggs<
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-geohexgrid-aggregation
+export type GeoHexGridAggs<
 	BaseQuery extends SearchRequest,
 	E extends ElasticsearchIndexes,
 	Index extends string,
 	Agg,
 > = Agg extends {
-	geotile_grid: {
+	geohex_grid: {
 		field: infer Field extends string;
 		precision?: infer Precision;
 	};
 }
 	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<GetPrecision<Precision>, Range_0_29> extends true
+		? IsSomeSortOf<GetPrecision<Precision>, Range_0_15> extends true
 			? {
 					buckets: PrettyArray<
 						{
-							key: `${GetPrecision<Precision>}/${number}/${number}`;
+							key: string;
 							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				}
-			: InvalidPropetyTypeInAggregation<"precision", Agg, Precision, Range_0_29>
+			: InvalidPropetyTypeInAggregation<"precision", Agg, Precision, Range_0_15>
 		: InvalidFieldInAggregation<Field, Index, Agg>
 	: never;

--- a/src/aggregations/bucket/geotile_grid.ts
+++ b/src/aggregations/bucket/geotile_grid.ts
@@ -3,7 +3,7 @@ import type {
 	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
 	InvalidFieldInAggregation,
-	InvalidPropetyTypeInAggregation,
+	InvalidPropertyTypeInAggregation,
 	SearchRequest,
 } from "../..";
 import type {
@@ -38,6 +38,11 @@ export type GeoTileGridAggs<
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				}
-			: InvalidPropetyTypeInAggregation<"precision", Agg, Precision, Range_0_29>
+			: InvalidPropertyTypeInAggregation<
+					"precision",
+					Agg,
+					Precision,
+					Range_0_29
+				>
 		: InvalidFieldInAggregation<Field, Index, Agg>
 	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -114,7 +114,7 @@ export type InvalidFieldTypeInAggregation<
 	expected: expected;
 };
 
-export type InvalidPropetyTypeInAggregation<
+export type InvalidPropertyTypeInAggregation<
 	PropertyName extends string,
 	Aggregation,
 	got,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,6 +7,7 @@ import type { CompositeAggs } from "./aggregations/bucket/composite";
 import type { DateHistogramAggs } from "./aggregations/bucket/date_histogram";
 import type { DateRangeAggs } from "./aggregations/bucket/date_range";
 import type { FiltersAggs } from "./aggregations/bucket/filters";
+import type { GeoHexGridAggs } from "./aggregations/bucket/geohex_grid";
 import type { GeoTileGridAggs } from "./aggregations/bucket/geotile_grid";
 import type { HistogramAggs } from "./aggregations/bucket/histogram";
 import type { RangeAggs } from "./aggregations/bucket/range";
@@ -107,7 +108,20 @@ export type InvalidFieldTypeInAggregation<
 	expected,
 > = {
 	error: `Field '${Field}' cannot be used in aggregation on '${Index}' because it is of type '${ToString<got>}' but expected '${ToString<expected>}'`;
+	field: Field;
 	aggregation: Aggregation;
+	got: got;
+	expected: expected;
+};
+
+export type InvalidPropetyTypeInAggregation<
+	PropertyName extends string,
+	Aggregation,
+	got,
+	expected,
+> = {
+	aggregation: Aggregation;
+	property: PropertyName;
 	got: got;
 	expected: expected;
 };
@@ -163,6 +177,7 @@ export type NextAggsParentKey<
 	| "geo_bounds"
 	| "geo_centroid"
 	| "geo_line"
+	| "geohex_grid"
 	| "geotile_grid"
 	| "histogram"
 	| "median_absolute_deviation"
@@ -193,6 +208,7 @@ export type AggregationOutput<
 			| DateHistogramAggs<BaseQuery, E, Index, Agg>
 			| DateRangeAggs<BaseQuery, E, Index, Agg>
 			| FiltersAggs<BaseQuery, E, Index, Agg>
+			| GeoHexGridAggs<BaseQuery, E, Index, Agg>
 			| GeoTileGridAggs<BaseQuery, E, Index, Agg>
 			| RangeAggs<BaseQuery, E, Index, Agg>
 			| TermsAggs<BaseQuery, E, Index, Agg>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -66,3 +66,13 @@ export type ToDecimal<N> = IsFloatLiteral<N> extends true
 	: IsNumericLiteral<N> extends true
 		? `${ToString<N>}.0`
 		: never;
+
+export type Enumerate<T extends number, Acc extends number[] = []> = T extends 0
+	? Acc
+	: Acc["length"] extends T
+		? Acc[number]
+		: Enumerate<T, [...Acc, Acc["length"]]>;
+
+export type RangeInclusive<T extends number, U extends number> =
+	| U
+	| Exclude<Enumerate<U>, Enumerate<T>>;

--- a/tests/aggregations/bucket/geohex_grid.test.ts
+++ b/tests/aggregations/bucket/geohex_grid.test.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, test } from "bun:test";
 import {
 	type ElasticsearchOutput,
 	type InvalidFieldInAggregation,
-	type InvalidPropetyTypeInAggregation,
+	type InvalidPropertyTypeInAggregation,
 	typedEs,
 } from "../../../src/index";
 import type { RangeInclusive } from "../../../src/types/helpers";
@@ -111,7 +111,7 @@ describe("GeoHexGrid Aggregations", () => {
 		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
 		type Aggregations = Output["aggregations"];
 		expectTypeOf<Aggregations>().toEqualTypeOf<{
-			invalid_stats: InvalidPropetyTypeInAggregation<
+			invalid_stats: InvalidPropertyTypeInAggregation<
 				"precision",
 				(typeof query)["aggs"]["invalid_stats"],
 				30,

--- a/tests/aggregations/bucket/geohex_grid.test.ts
+++ b/tests/aggregations/bucket/geohex_grid.test.ts
@@ -1,0 +1,146 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	type InvalidPropetyTypeInAggregation,
+	typedEs,
+} from "../../../src/index";
+import type { RangeInclusive } from "../../../src/types/helpers";
+import { type CustomIndexes, client } from "../../shared";
+
+describe("GeoHexGrid Aggregations", () => {
+	test("with default values", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggregations: {
+				"large-grid": {
+					geohex_grid: {
+						field: "shipping_address.geo_point",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			"large-grid": {
+				buckets: Array<{
+					key: string;
+					doc_count: number;
+				}>;
+			};
+		}>();
+	});
+
+	test("with higher precision", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggregations: {
+				"large-grid": {
+					geohex_grid: {
+						field: "shipping_address.geo_point",
+						precision: 12,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			"large-grid": {
+				buckets: Array<{
+					key: string;
+					doc_count: number;
+				}>;
+			};
+		}>();
+	});
+
+	test("supports nested sub-aggregations in buckets", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			size: 0,
+			_source: false,
+			aggs: {
+				grid: {
+					geohex_grid: { field: "shipping_address.geo_point", precision: 8 },
+					aggs: {
+						by_status: { terms: { field: "status" } },
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			grid: {
+				buckets: Array<{
+					key: string;
+					doc_count: number;
+					by_status: {
+						doc_count_error_upper_bound: number;
+						sum_other_doc_count: number;
+						buckets: Array<{
+							key: "pending" | "completed" | "cancelled";
+							doc_count: number;
+						}>;
+					};
+				}>;
+			};
+		}>();
+	});
+
+	test("fails when using a out of range precision", () => {
+		const query = typedEs(client, {
+			index: "orders",
+			_source: false,
+			size: 0,
+			aggs: {
+				invalid_stats: {
+					geohex_grid: {
+						field: "shipping_address.geo_point",
+						precision: 30,
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			invalid_stats: InvalidPropetyTypeInAggregation<
+				"precision",
+				(typeof query)["aggs"]["invalid_stats"],
+				30,
+				RangeInclusive<0, 15>
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			_source: false,
+			size: 0,
+			aggs: {
+				invalid_stats: {
+					geohex_grid: {
+						field: "invalid",
+					},
+				},
+			},
+		});
+		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
+		type Aggregations = Output["aggregations"];
+		expectTypeOf<Aggregations>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				(typeof query)["aggs"]["invalid_stats"]
+			>;
+		}>();
+	});
+});

--- a/tests/aggregations/bucket/geotile_grid.test.ts
+++ b/tests/aggregations/bucket/geotile_grid.test.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, test } from "bun:test";
 import {
 	type ElasticsearchOutput,
 	type InvalidFieldInAggregation,
-	type InvalidPropetyTypeInAggregation,
+	type InvalidPropertyTypeInAggregation,
 	typedEs,
 } from "../../../src/index";
 import type { RangeInclusive } from "../../../src/types/helpers";
@@ -111,7 +111,7 @@ describe("Geotile Aggregations", () => {
 		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
 		type Aggregations = Output["aggregations"];
 		expectTypeOf<Aggregations>().toEqualTypeOf<{
-			invalid_stats: InvalidPropetyTypeInAggregation<
+			invalid_stats: InvalidPropertyTypeInAggregation<
 				"precision",
 				(typeof query)["aggs"]["invalid_stats"],
 				30,


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the geohex_grid bucket aggregation and new exported validation type for invalid aggregation properties.
  - Added numeric-range helper types to support precision validation.
- **Bug Fixes**
  - Enforced precision range validation: geohex_grid (0–15) and geotile_grid (0–29) now produce clear type errors for out-of-range values.
- **Tests**
  - Added comprehensive type-level tests for geohex_grid, geotile_grid, nested sub-aggregations, and invalid precision cases.
- **Chores**
  - Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->