### PR TITLE
add TestAggregationOutput type util

### DIFF
--- a/tests/aggregations/bucket/composite.test.ts
+++ b/tests/aggregations/bucket/composite.test.ts
@@ -1,40 +1,39 @@
 import { describe, expectTypeOf, test } from "bun:test";
 import { type ElasticsearchOutput, typedEs } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import {
+	type CustomIndexes,
+	client,
+	type TestAggregationOutput,
+} from "../../shared";
 
 describe("Composite Aggregations", () => {
 	test("with pagination", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			size: 10,
-			from: 0,
-			_source: ["score"],
-			aggregations: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				page: {
 					composite: {
-						size: 10,
+						size: 10;
 						sources: [
 							{ entity: { terms: { field: "entity_id" } } },
 							{ key2: { terms: { field: "score" } } },
-						],
-					},
+						];
+					};
 					aggs: {
 						daily: {
 							date_histogram: {
-								field: "date",
-								calendar_interval: "day",
-							},
+								field: "date";
+								calendar_interval: "day";
+							};
 							aggs: {
-								score_value: { sum: { field: "score" } },
-							},
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+								score_value: { sum: { field: "score" } };
+							};
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			page: {
 				after_key: Record<"entity" | "key2", unknown>;
 				buckets: Array<{
@@ -54,43 +53,34 @@ describe("Composite Aggregations", () => {
 				}>;
 			};
 		}>();
-
-		expectTypeOf<Output["hits"]["hits"][0]["_source"]>().toEqualTypeOf<{
-			score: number;
-		}>();
 	});
 
 	test("with multiple aggregations", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				pagination: {
 					composite: {
-						after: undefined,
 						sources: [
 							{ entity: { terms: { field: "entity_id" } } },
 							{ key2: { terms: { field: "score" } } },
-						],
-					},
+						];
+					};
 					aggs: {
 						max_date: {
-							max: { field: "created_at" },
-						},
+							max: { field: "created_at" };
+						};
 						min_date: {
-							min: { field: "created_at" },
-						},
+							min: { field: "created_at" };
+						};
 						terms_field: {
-							terms: { field: "product_ids" },
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+							terms: { field: "product_ids" };
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			pagination: {
 				after_key: Record<"entity" | "key2", unknown>;
 				buckets: Array<{

--- a/tests/aggregations/bucket/date_histogram.test.ts
+++ b/tests/aggregations/bucket/date_histogram.test.ts
@@ -1,47 +1,39 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Date Histogram Aggregations", () => {
 	test("with nested date_histogram", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				years: {
 					date_histogram: {
-						field: "date",
-						calendar_interval: "year",
-					},
+						field: "date";
+						calendar_interval: "year";
+					};
 					aggregations: {
 						daily: {
 							date_histogram: {
-								field: "date",
-								calendar_interval: "day",
-							},
+								field: "date";
+								calendar_interval: "day";
+							};
 							aggs: {
-								score_value: { sum: { field: "score" } },
-							},
-						},
+								score_value: { sum: { field: "score" } };
+							};
+						};
 						yearly_avg: {
 							avg_bucket: {
-								buckets_path: "daily>score_value",
-								gap_policy: "insert_zeros",
-							},
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
+								buckets_path: "daily>score_value";
+								gap_policy: "insert_zeros";
+							};
+						};
+					};
+				};
+			}
+		>;
 
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			years: {
 				buckets: Array<{
 					key_as_string: string;
@@ -68,24 +60,20 @@ describe("Date Histogram Aggregations", () => {
 	});
 
 	test("with keyed", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				sales_over_time: {
 					date_histogram: {
-						field: "date",
-						calendar_interval: "1M",
-						format: "yyyy-MM-dd",
-						keyed: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "date";
+						calendar_interval: "1M";
+						format: "yyyy-MM-dd";
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			sales_over_time: {
 				buckets: Record<
 					string,
@@ -100,27 +88,23 @@ describe("Date Histogram Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				sales_over_time: {
 					date_histogram: {
-						field: "invalid",
-						calendar_interval: "1M",
-						format: "yyyy-MM-dd",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+						calendar_interval: "1M";
+						format: "yyyy-MM-dd";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			sales_over_time: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["sales_over_time"]
+				Aggregations["input"]["sales_over_time"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/bucket/date_range.test.ts
+++ b/tests/aggregations/bucket/date_range.test.ts
@@ -1,35 +1,27 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-daterange-aggregation
 describe("DateRange Aggregations", () => {
 	test("with from-to", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				range: {
 					date_range: {
-						field: "date",
-						format: "MM-yyyy",
+						field: "date";
+						format: "MM-yyyy";
 						ranges: [
 							{ to: "2016/02/01" },
-							{ from: "2016/02/01", to: "now/d" },
+							{ from: "2016/02/01"; to: "now/d" },
 							{ from: "now/d" },
-						],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			range: {
 				buckets: [
 					{
@@ -58,24 +50,20 @@ describe("DateRange Aggregations", () => {
 	});
 
 	test("with keyed", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				range: {
 					date_range: {
-						field: "date",
-						format: "MM-yyy",
-						ranges: [{ to: "now-10M/M" }, { from: "now-10M/M" }],
-						keyed: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "date";
+						format: "MM-yyy";
+						ranges: [{ to: "now-10M/M" }, { from: "now-10M/M" }];
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			range: {
 				buckets: {
 					[x: `*-${string}`]: {
@@ -94,28 +82,24 @@ describe("DateRange Aggregations", () => {
 	});
 
 	test("with keyed and custom key", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				range: {
 					date_range: {
-						field: "date",
-						format: "MM-yyy",
+						field: "date";
+						format: "MM-yyy";
 						ranges: [
-							{ from: "01-2015", to: "03-2015", key: "quarter_01" },
-							{ from: "03-2015", to: "06-2015", key: "quarter_02" },
-							{ from: "06-2015", key: "quarter_03_to_now" },
-						],
-						keyed: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+							{ from: "01-2015"; to: "03-2015"; key: "quarter_01" },
+							{ from: "03-2015"; to: "06-2015"; key: "quarter_02" },
+							{ from: "06-2015"; key: "quarter_03_to_now" },
+						];
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			range: {
 				buckets: {
 					quarter_01: {
@@ -143,28 +127,24 @@ describe("DateRange Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				range: {
 					date_range: {
-						field: "invalid",
-						format: "MM-yyy",
-						ranges: [{ from: "01-2015", to: "03-2015", key: "quarter_01" }],
-						keyed: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+						format: "MM-yyy";
+						ranges: [{ from: "01-2015"; to: "03-2015"; key: "quarter_01" }];
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			range: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["range"]
+				Aggregations["input"]["range"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/bucket/filters.test.ts
+++ b/tests/aggregations/bucket/filters.test.ts
@@ -1,28 +1,23 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import { type ElasticsearchOutput, typedEs } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filters-aggregation
 describe("Filters Aggregations", () => {
 	test("with anonymous filters", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				messages: {
 					filters: {
 						filters: [
 							{ match: { body: "error" } },
 							{ match: { body: "warning" } },
-						],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			messages: {
 				buckets: Array<{
 					doc_count: number;
@@ -32,24 +27,20 @@ describe("Filters Aggregations", () => {
 	});
 
 	test("with named filters", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				messages: {
 					filters: {
 						filters: {
-							errors: { match: { body: "error" } },
-							warnings: { match: { body: "warning" } },
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+							errors: { match: { body: "error" } };
+							warnings: { match: { body: "warning" } };
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			messages: {
 				buckets: {
 					errors: {
@@ -64,24 +55,20 @@ describe("Filters Aggregations", () => {
 	});
 
 	test("with named filters and other_bucket_key", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				messages: {
 					filters: {
 						filters: {
-							warnings: { match: { body: "warning" } },
-						},
-						other_bucket_key: "another_key",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+							warnings: { match: { body: "warning" } };
+						};
+						other_bucket_key: "another_key";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			messages: {
 				buckets: {
 					another_key: {
@@ -96,27 +83,23 @@ describe("Filters Aggregations", () => {
 	});
 
 	test("Should support `keyed` parameter", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				messages: {
 					filters: {
 						filters: {
-							errors: { match: { body: "error" } },
-							warnings: { match: { body: "warning" } },
-						},
-						other_bucket_key: "another_key",
-						keyed: false,
-					},
-				},
-			},
-		});
+							errors: { match: { body: "error" } };
+							warnings: { match: { body: "warning" } };
+						};
+						other_bucket_key: "another_key";
+						keyed: false;
+					};
+				};
+			}
+		>;
 
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			messages: {
 				buckets: Array<{
 					key: "errors" | "warnings" | "another_key";
@@ -127,31 +110,27 @@ describe("Filters Aggregations", () => {
 	});
 
 	test("Should support nested aggregations", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				the_filter: {
 					filters: {
-						keyed: false,
+						keyed: false;
 						filters: {
-							"t-shirt": { term: { type: "t-shirt" } },
-							hat: { term: { type: "hat" } },
-						},
-					},
+							"t-shirt": { term: { type: "t-shirt" } };
+							hat: { term: { type: "hat" } };
+						};
+					};
 					aggs: {
-						avg_price: { avg: { field: "score" } },
+						avg_price: { avg: { field: "score" } };
 						sort_by_avg_price: {
-							bucket_sort: { sort: { avg_price: "asc" } },
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+							bucket_sort: { sort: { avg_price: "asc" } };
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			the_filter: {
 				buckets: Array<{
 					key: "t-shirt" | "hat";

--- a/tests/aggregations/bucket/geohex_grid.test.ts
+++ b/tests/aggregations/bucket/geohex_grid.test.ts
@@ -1,30 +1,24 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	type InvalidPropertyTypeInAggregation,
-	typedEs,
+import type {
+	InvalidFieldInAggregation,
+	InvalidPropertyTypeInAggregation,
 } from "../../../src/index";
 import type { RangeInclusive } from "../../../src/types/helpers";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("GeoHexGrid Aggregations", () => {
 	test("with default values", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggregations: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				"large-grid": {
 					geohex_grid: {
-						field: "shipping_address.geo_point",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			"large-grid": {
 				buckets: Array<{
 					key: string;
@@ -35,22 +29,18 @@ describe("GeoHexGrid Aggregations", () => {
 	});
 
 	test("with higher precision", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggregations: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				"large-grid": {
 					geohex_grid: {
-						field: "shipping_address.geo_point",
-						precision: 12,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+						precision: 12;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			"large-grid": {
 				buckets: Array<{
 					key: string;
@@ -61,22 +51,18 @@ describe("GeoHexGrid Aggregations", () => {
 	});
 
 	test("supports nested sub-aggregations in buckets", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				grid: {
-					geohex_grid: { field: "shipping_address.geo_point", precision: 8 },
+					geohex_grid: { field: "shipping_address.geo_point"; precision: 8 };
 					aggs: {
-						by_status: { terms: { field: "status" } },
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						by_status: { terms: { field: "status" } };
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			grid: {
 				buckets: Array<{
 					key: string;
@@ -95,25 +81,21 @@ describe("GeoHexGrid Aggregations", () => {
 	});
 
 	test("fails when using a out of range precision", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				invalid_stats: {
 					geohex_grid: {
-						field: "shipping_address.geo_point",
-						precision: 30,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+						precision: 30;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidPropertyTypeInAggregation<
 				"precision",
-				(typeof query)["aggs"]["invalid_stats"],
+				Aggregations["input"]["invalid_stats"],
 				30,
 				RangeInclusive<0, 15>
 			>;
@@ -121,25 +103,21 @@ describe("GeoHexGrid Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				invalid_stats: {
 					geohex_grid: {
-						field: "invalid",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["invalid_stats"]
+				Aggregations["input"]["invalid_stats"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/bucket/geotile_grid.test.ts
+++ b/tests/aggregations/bucket/geotile_grid.test.ts
@@ -1,30 +1,24 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	type InvalidPropertyTypeInAggregation,
-	typedEs,
+import type {
+	InvalidFieldInAggregation,
+	InvalidPropertyTypeInAggregation,
 } from "../../../src/index";
 import type { RangeInclusive } from "../../../src/types/helpers";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Geotile Aggregations", () => {
 	test("with default values", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggregations: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				"large-grid": {
 					geotile_grid: {
-						field: "shipping_address.geo_point",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			"large-grid": {
 				buckets: Array<{
 					key: `7/${number}/${number}`;
@@ -35,22 +29,18 @@ describe("Geotile Aggregations", () => {
 	});
 
 	test("with higher precision", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggregations: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				"large-grid": {
 					geotile_grid: {
-						field: "shipping_address.geo_point",
-						precision: 22,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+						precision: 22;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			"large-grid": {
 				buckets: Array<{
 					key: `22/${number}/${number}`;
@@ -61,22 +51,18 @@ describe("Geotile Aggregations", () => {
 	});
 
 	test("supports nested sub-aggregations in buckets", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				grid: {
-					geotile_grid: { field: "shipping_address.geo_point", precision: 8 },
+					geotile_grid: { field: "shipping_address.geo_point"; precision: 8 };
 					aggs: {
-						by_status: { terms: { field: "status" } },
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						by_status: { terms: { field: "status" } };
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			grid: {
 				buckets: Array<{
 					key: `8/${number}/${number}`;
@@ -95,25 +81,21 @@ describe("Geotile Aggregations", () => {
 	});
 
 	test("fails when using a out of range precision", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				invalid_stats: {
 					geotile_grid: {
-						field: "shipping_address.geo_point",
-						precision: 30,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+						precision: 30;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidPropertyTypeInAggregation<
 				"precision",
-				(typeof query)["aggs"]["invalid_stats"],
+				Aggregations["input"]["invalid_stats"],
 				30,
 				RangeInclusive<0, 29>
 			>;
@@ -121,25 +103,21 @@ describe("Geotile Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				invalid_stats: {
 					geotile_grid: {
-						field: "invalid",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["invalid_stats"]
+				Aggregations["input"]["invalid_stats"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/bucket/histogram.test.ts
+++ b/tests/aggregations/bucket/histogram.test.ts
@@ -1,30 +1,22 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-histogram-aggregation
 describe("Histogram Aggregations", () => {
 	test("default", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				prices: {
 					histogram: {
-						field: "score",
-						interval: 50,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "score";
+						interval: 50;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			prices: {
 				buckets: Array<{
 					key: number;
@@ -35,23 +27,19 @@ describe("Histogram Aggregations", () => {
 	});
 
 	test("with keyed", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				prices: {
 					histogram: {
-						field: "score",
-						interval: 50,
-						keyed: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "score";
+						interval: 50;
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			prices: {
 				buckets: Record<
 					`${number}`,
@@ -65,26 +53,22 @@ describe("Histogram Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				prices: {
 					histogram: {
-						field: "invalid",
-						interval: 50,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+						interval: 50;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			prices: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["prices"]
+				Aggregations["input"]["prices"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/bucket/range.test.ts
+++ b/tests/aggregations/bucket/range.test.ts
@@ -1,37 +1,29 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-range-aggregation
 describe("Range Aggregations", () => {
 	test("with from-to", () => {
 		const startRange = 100 as number;
 		const midRange = 200 as number;
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				price_ranges: {
 					range: {
-						field: "score",
+						field: "score";
 						ranges: [
-							{ to: startRange },
-							{ from: startRange, to: midRange },
-							{ from: midRange, to: 500 },
+							{ to: typeof startRange },
+							{ from: typeof startRange; to: typeof midRange },
+							{ from: typeof midRange; to: 500 },
 							{ from: 500.0 },
-						],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			price_ranges: {
 				buckets: [
 					{
@@ -62,26 +54,22 @@ describe("Range Aggregations", () => {
 	});
 
 	test("with explicit from-to", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				price_ranges: {
 					range: {
-						field: "score",
+						field: "score";
 						ranges: [
 							{ to: 100.1 },
-							{ from: 100.1, to: 200.0 },
+							{ from: 100.1; to: 200.0 },
 							{ from: 200.0 },
-						],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			price_ranges: {
 				buckets: [
 					{
@@ -106,23 +94,19 @@ describe("Range Aggregations", () => {
 	});
 
 	test("with keyed", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				price_ranges: {
 					range: {
-						field: "score",
-						keyed: true,
-						ranges: [{ to: 100 }, { from: 100, to: 200 }, { from: 200 }],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "score";
+						keyed: true;
+						ranges: [{ to: 100 }, { from: 100; to: 200 }, { from: 200 }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			price_ranges: {
 				buckets: {
 					"*-100.0": {
@@ -144,27 +128,23 @@ describe("Range Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				price_ranges: {
 					range: {
-						field: "invalid",
-						keyed: true,
-						ranges: [{ to: 100 }, { from: 100, to: 200 }, { from: 200 }],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+						keyed: true;
+						ranges: [{ to: 100 }, { from: 100; to: 200 }, { from: 200 }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			price_ranges: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["price_ranges"]
+				Aggregations["input"]["price_ranges"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/bucket/terms.test.ts
+++ b/tests/aggregations/bucket/terms.test.ts
@@ -1,39 +1,32 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Terms Aggregations", () => {
 	test("without other aggs", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				number_agg: {
 					terms: {
-						field: "user_id",
-					},
-				},
+						field: "user_id";
+					};
+				};
 				string_agg: {
 					terms: {
-						field: "product_ids",
-					},
-				},
+						field: "product_ids";
+					};
+				};
 				string_enum_agg: {
 					terms: {
-						field: "status",
-						size: 10,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "status";
+						size: 10;
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			number_agg: {
 				doc_count_error_upper_bound: number;
 				sum_other_doc_count: number;
@@ -62,25 +55,21 @@ describe("Terms Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				terms_agg: {
 					terms: {
-						field: "invalid",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			terms_agg: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["terms_agg"]
+				Aggregations["input"]["terms_agg"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/extended_stats.test.ts
+++ b/tests/aggregations/metrics/extended_stats.test.ts
@@ -1,28 +1,20 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Extended Stats Aggregations", () => {
 	test("with extended_stats on number field", () => {
-		const query = typedEs(client, {
-			index: "test_types",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"test_types",
+			{
 				price_stats: {
 					extended_stats: {
-						field: "price",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "price";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			price_stats: {
 				count: number;
 				min: number;
@@ -66,25 +58,21 @@ describe("Extended Stats Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				invalid_stats: {
 					extended_stats: {
-						field: "invalid_field",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid_field";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidFieldInAggregation<
 				"invalid_field",
 				"demo",
-				(typeof query)["aggs"]["invalid_stats"]
+				Aggregations["input"]["invalid_stats"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/function.test.ts
+++ b/tests/aggregations/metrics/function.test.ts
@@ -135,125 +135,117 @@ describe("Leaf Function Aggregations", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				min_value: {
 					min: {
-						field: "price",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "price";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			min_value: InvalidFieldInAggregation<
 				"price",
 				"demo",
-				(typeof query)["aggs"]["min_value"]
+				Aggregations["input"]["min_value"]
 			>;
 		}>();
 	});
 
 	test("output type should be correct for all agg functions", () => {
-		const query = typedEs(client, {
-			index: "test_types",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"test_types",
+			{
 				str_min: {
 					min: {
-						field: "name",
-					},
-				},
+						field: "name";
+					};
+				};
 				num_min: {
 					min: {
-						field: "price",
-					},
-				},
+						field: "price";
+					};
+				};
 				date_min: {
 					min: {
-						field: "timestamp",
-					},
-				},
+						field: "timestamp";
+					};
+				};
 				//
 				str_max: {
 					max: {
-						field: "name",
-					},
-				},
+						field: "name";
+					};
+				};
 				num_max: {
 					max: {
-						field: "price",
-					},
-				},
+						field: "price";
+					};
+				};
 				date_max: {
 					max: {
-						field: "timestamp",
-					},
-				},
+						field: "timestamp";
+					};
+				};
 				//
 				num_avg: {
 					avg: {
-						field: "price",
-					},
-				},
+						field: "price";
+					};
+				};
 				date_avg: {
 					avg: {
-						field: "timestamp",
-					},
-				},
+						field: "timestamp";
+					};
+				};
 				//
 				num_sum: {
 					sum: {
-						field: "price",
-					},
-				},
+						field: "price";
+					};
+				};
 				date_sum: {
 					sum: {
-						field: "timestamp",
-					},
-				},
+						field: "timestamp";
+					};
+				};
 				//
 				str_value_count: {
 					value_count: {
-						field: "name",
-					},
-				},
+						field: "name";
+					};
+				};
 				num_value_count: {
 					value_count: {
-						field: "price",
-					},
-				},
+						field: "price";
+					};
+				};
 				date_value_count: {
 					value_count: {
-						field: "timestamp",
-					},
-				},
+						field: "timestamp";
+					};
+				};
 				//
 				str_cardinality: {
 					cardinality: {
-						field: "name",
-					},
-				},
+						field: "name";
+					};
+				};
 				num_cardinality: {
 					cardinality: {
-						field: "price",
-					},
-				},
+						field: "price";
+					};
+				};
 				date_cardinality: {
 					cardinality: {
-						field: "timestamp",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "timestamp";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			str_min: {
 				value: number | string;
 				value_as_string?: string;

--- a/tests/aggregations/metrics/function.test.ts
+++ b/tests/aggregations/metrics/function.test.ts
@@ -1,6 +1,14 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
-import type { TestAggregationOutput } from "../../shared";
+import {
+	type ElasticsearchOutput,
+	type InvalidFieldInAggregation,
+	typedEs,
+} from "../../../src/index";
+import {
+	type CustomIndexes,
+	client,
+	type TestAggregationOutput,
+} from "../../shared";
 
 describe("Leaf Function Aggregations", () => {
 	test("with min", () => {

--- a/tests/aggregations/metrics/function.test.ts
+++ b/tests/aggregations/metrics/function.test.ts
@@ -1,28 +1,20 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Leaf Function Aggregations", () => {
 	test("with min", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				min_value: {
 					min: {
-						field: "total",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			min_value: {
 				value: number;
 				value_as_string?: string;

--- a/tests/aggregations/metrics/geo_bounds.test.ts
+++ b/tests/aggregations/metrics/geo_bounds.test.ts
@@ -1,29 +1,21 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("GeoBounds Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				viewport: {
 					geo_bounds: {
-						field: "shipping_address.geo_point",
-						wrap_longitude: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+						wrap_longitude: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			viewport: {
 				bounds: {
 					top_left: {
@@ -40,26 +32,22 @@ describe("GeoBounds Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				viewport: {
 					geo_bounds: {
-						field: "invalid",
-						wrap_longitude: true,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+						wrap_longitude: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			viewport: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["viewport"]
+				Aggregations["input"]["viewport"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/geo_centroid.test.ts
+++ b/tests/aggregations/metrics/geo_centroid.test.ts
@@ -1,28 +1,20 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Geo Centroid Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				centroid: {
 					geo_centroid: {
-						field: "shipping_address.geo_point",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "shipping_address.geo_point";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			centroid: {
 				location: {
 					lat: number;
@@ -34,24 +26,20 @@ describe("Geo Centroid Aggregation", () => {
 	});
 
 	test("in a nested query", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				cities: {
-					terms: { field: "shipping_address.city" },
+					terms: { field: "shipping_address.city" };
 					aggs: {
 						centroid: {
-							geo_centroid: { field: "shipping_address.geo_point" },
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+							geo_centroid: { field: "shipping_address.geo_point" };
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			cities: {
 				doc_count_error_upper_bound: number;
 				sum_other_doc_count: number;
@@ -71,25 +59,21 @@ describe("Geo Centroid Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				centroid: {
 					geo_centroid: {
-						field: "invalid",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			centroid: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["centroid"]
+				Aggregations["input"]["centroid"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/geo_line.test.ts
+++ b/tests/aggregations/metrics/geo_line.test.ts
@@ -1,29 +1,21 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("GeoLine Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				line: {
 					geo_line: {
-						point: { field: "shipping_address.geo_point" },
-						sort: { field: "date" },
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						point: { field: "shipping_address.geo_point" };
+						sort: { field: "date" };
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			line: {
 				type: "Feature";
 				geometry: {
@@ -38,27 +30,23 @@ describe("GeoLine Aggregation", () => {
 	});
 
 	test("with terms aggregation", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggregations: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				path: {
-					terms: { field: "shipping_address.city" },
+					terms: { field: "shipping_address.city" };
 					aggregations: {
 						museum_tour: {
 							geo_line: {
-								point: { field: "shipping_address.geo_point" },
-								sort: { field: "date" },
-							},
-						},
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+								point: { field: "shipping_address.geo_point" };
+								sort: { field: "date" };
+							};
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			path: {
 				doc_count_error_upper_bound: number;
 				sum_other_doc_count: number;
@@ -81,26 +69,22 @@ describe("GeoLine Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				line: {
 					geo_line: {
-						point: { field: "invalid" },
-						sort: { field: "date" },
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						point: { field: "invalid" };
+						sort: { field: "date" };
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			line: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["line"]
+				Aggregations["input"]["line"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/median_absolute_deviation.test.ts
+++ b/tests/aggregations/metrics/median_absolute_deviation.test.ts
@@ -1,34 +1,28 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	type InvalidFieldTypeInAggregation,
-	typedEs,
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
 } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Median Absolute Deviation Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
 				review_average: {
 					avg: {
-						field: "rating",
-					},
-				},
+						field: "rating";
+					};
+				};
 				review_variability: {
 					median_absolute_deviation: {
-						field: "rating",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "rating";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			review_average: {
 				value_as_string?: string;
 				value: number;
@@ -40,26 +34,22 @@ describe("Median Absolute Deviation Aggregation", () => {
 	});
 
 	test("fails when using an invalid type field", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
 				review_average: {
 					avg: {
-						field: "rating",
-					},
-				},
+						field: "rating";
+					};
+				};
 				review_variability: {
 					median_absolute_deviation: {
-						field: "id",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "id";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			review_average: {
 				value_as_string?: string;
 				value: number;
@@ -67,7 +57,7 @@ describe("Median Absolute Deviation Aggregation", () => {
 			review_variability: InvalidFieldTypeInAggregation<
 				"id",
 				"reviews",
-				(typeof query)["aggs"]["review_variability"],
+				Aggregations["input"]["review_variability"],
 				string,
 				number
 			>;
@@ -75,26 +65,22 @@ describe("Median Absolute Deviation Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
 				review_average: {
 					avg: {
-						field: "rating",
-					},
-				},
+						field: "rating";
+					};
+				};
 				review_variability: {
 					median_absolute_deviation: {
-						field: "invalid",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			review_average: {
 				value_as_string?: string;
 				value: number;
@@ -102,7 +88,7 @@ describe("Median Absolute Deviation Aggregation", () => {
 			review_variability: InvalidFieldInAggregation<
 				"invalid",
 				"reviews",
-				(typeof query)["aggs"]["review_variability"]
+				Aggregations["input"]["review_variability"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/percentile_ranks.test.ts
+++ b/tests/aggregations/metrics/percentile_ranks.test.ts
@@ -1,30 +1,24 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	type InvalidFieldTypeInAggregation,
-	typedEs,
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
 } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("PercentileRanks Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_ranks: {
 					percentile_ranks: {
-						field: "total",
-						values: [500, 600],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total";
+						values: [500, 600];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_ranks: {
 				values: {
 					"500.0": number;
@@ -35,23 +29,19 @@ describe("PercentileRanks Aggregation", () => {
 	});
 
 	test("with keyed=false", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_ranks: {
 					percentile_ranks: {
-						field: "total",
-						values: [500, 600],
-						keyed: false,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total";
+						values: [500, 600];
+						keyed: false;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_ranks: {
 				values: [
 					{
@@ -68,26 +58,22 @@ describe("PercentileRanks Aggregation", () => {
 	});
 
 	test("fails when using an invalid type field", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_ranks: {
 					percentile_ranks: {
-						field: "id",
-						values: [500, 600],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "id";
+						values: [500, 600];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_ranks: InvalidFieldTypeInAggregation<
 				"id",
 				"orders",
-				(typeof query)["aggs"]["load_time_ranks"],
+				Aggregations["input"]["load_time_ranks"],
 				string,
 				number
 			>;
@@ -95,26 +81,22 @@ describe("PercentileRanks Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				load_time_ranks: {
 					percentile_ranks: {
-						field: "invalid",
-						values: [500, 600],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+						values: [500, 600];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_ranks: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["load_time_ranks"]
+				Aggregations["input"]["load_time_ranks"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/percentiles.test.ts
+++ b/tests/aggregations/metrics/percentiles.test.ts
@@ -1,29 +1,23 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	type InvalidFieldTypeInAggregation,
-	typedEs,
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
 } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Percentiles Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_outlier: {
 					percentiles: {
-						field: "total",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_outlier: {
 				values: {
 					"1.0": number;
@@ -39,22 +33,18 @@ describe("Percentiles Aggregation", () => {
 	});
 
 	test("with custom percents", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_outlier: {
 					percentiles: {
-						field: "total",
-						percents: [95, 99, 99.9],
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total";
+						percents: [95, 99, 99.9];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_outlier: {
 				values: {
 					"95.0": number;
@@ -66,22 +56,18 @@ describe("Percentiles Aggregation", () => {
 	});
 
 	test("with keyed=false", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_outlier: {
 					percentiles: {
-						field: "total.some_format",
-						keyed: false,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total.some_format";
+						keyed: false;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_outlier: {
 				values: [
 					{
@@ -118,26 +104,22 @@ describe("Percentiles Aggregation", () => {
 	});
 
 	test("fails when using an invalid type field", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				load_time_outlier: {
 					percentiles: {
-						field: "id",
-						keyed: false,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "id";
+						keyed: false;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_outlier: InvalidFieldTypeInAggregation<
 				"id",
 				"orders",
-				(typeof query)["aggs"]["load_time_outlier"],
+				Aggregations["input"]["load_time_outlier"],
 				string,
 				number
 			>;
@@ -145,25 +127,21 @@ describe("Percentiles Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				load_time_outlier: {
 					percentiles: {
-						field: "invalid",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			load_time_outlier: InvalidFieldInAggregation<
 				"invalid",
 				"demo",
-				(typeof query)["aggs"]["load_time_outlier"]
+				Aggregations["input"]["load_time_outlier"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/scripted_metric.test.ts
+++ b/tests/aggregations/metrics/scripted_metric.test.ts
@@ -1,44 +1,39 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import { type ElasticsearchOutput, typedEs } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("scripted_metric Aggregations", () => {
 	test("simulate a top_hits", () => {
 		// Example taken from: https://www.elastic.co/docs/explore-analyze/transforms/transform-painless-examples#painless-top-hits
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				max_score: {
 					max: {
-						field: "total",
-					},
-				},
+						field: "total";
+					};
+				};
 				latest_doc: {
 					scripted_metric: {
-						init_script: "state.timestamp_latest = 0L; state.last_doc = ''",
+						init_script: "state.timestamp_latest = 0L; state.last_doc = ''";
 						map_script: `
 def current_date = doc['@timestamp'].getValue().toInstant().toEpochMilli();
 if (current_date > state.timestamp_latest)
 {state.timestamp_latest = current_date;
 state.last_doc = new HashMap(params['_source']);}
-      `,
-						combine_script: "return state",
+      `;
+						combine_script: "return state";
 						reduce_script: `
 def last_doc = '';
 def timestamp_latest = 0L;
 for (s in states) {if (s.timestamp_latest > (timestamp_latest))
 {timestamp_latest = s.timestamp_latest; last_doc = s.last_doc;}}
 return last_doc
-      `,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+      `;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			max_score: {
 				value: number;
 				value_as_string?: string;

--- a/tests/aggregations/metrics/stats.test.ts
+++ b/tests/aggregations/metrics/stats.test.ts
@@ -1,28 +1,20 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	typedEs,
-} from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Stats Aggregation", () => {
 	test("with stats on numeric field", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				total_stats: {
 					stats: {
-						field: "total",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "total";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			total_stats: {
 				count: number;
 				min: number;
@@ -38,25 +30,21 @@ describe("Stats Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "demo",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
 				invalid_stats: {
 					stats: {
-						field: "price",
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						field: "price";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidFieldInAggregation<
 				"price",
 				"demo",
-				(typeof query)["aggs"]["invalid_stats"]
+				Aggregations["input"]["invalid_stats"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/string_stats.test.ts
+++ b/tests/aggregations/metrics/string_stats.test.ts
@@ -1,27 +1,21 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import {
-	type ElasticsearchOutput,
-	type InvalidFieldInAggregation,
-	type InvalidFieldTypeInAggregation,
-	typedEs,
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
 } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("String Stats Aggregation", () => {
 	test("simple", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
 				rating_stats: {
-					string_stats: { field: "rating.string" },
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+					string_stats: { field: "rating.string" };
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			rating_stats: {
 				count: number;
 				min_length: number;
@@ -33,19 +27,15 @@ describe("String Stats Aggregation", () => {
 	});
 
 	test("with show_distribution", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
 				rating_stats: {
-					string_stats: { field: "rating.string", show_distribution: true },
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+					string_stats: { field: "rating.string"; show_distribution: true };
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			rating_stats: {
 				count: number;
 				min_length: number;
@@ -58,21 +48,17 @@ describe("String Stats Aggregation", () => {
 	});
 
 	test("fails when using an invalid type field", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			_source: false,
-			size: 0,
-			aggs: {
-				rating_stats: { string_stats: { field: "rating" } },
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
+				rating_stats: { string_stats: { field: "rating" } };
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			rating_stats: InvalidFieldTypeInAggregation<
 				"rating",
 				"reviews",
-				(typeof query)["aggs"]["rating_stats"],
+				Aggregations["input"]["rating_stats"],
 				number,
 				string
 			>;
@@ -80,23 +66,19 @@ describe("String Stats Aggregation", () => {
 	});
 
 	test("fails when using an invalid field", () => {
-		const query = typedEs(client, {
-			index: "reviews",
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"reviews",
+			{
 				invalid_stats: {
-					string_stats: { field: "invalid" },
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+					string_stats: { field: "invalid" };
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			invalid_stats: InvalidFieldInAggregation<
 				"invalid",
 				"reviews",
-				(typeof query)["aggs"]["invalid_stats"]
+				Aggregations["input"]["invalid_stats"]
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/top_hits.test.ts
+++ b/tests/aggregations/metrics/top_hits.test.ts
@@ -1,45 +1,38 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import { type ElasticsearchOutput, typedEs } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("Top Hits Aggregations", () => {
 	test("top_hits query construction", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			rest_total_hits_as_int: true,
-			_source: false,
-			size: 0,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				top_tags: {
 					terms: {
-						field: "product_ids",
-						size: 3,
-					},
+						field: "product_ids";
+						size: 3;
+					};
 					aggs: {
 						top_sales_hits: {
 							top_hits: {
 								sort: [
 									{
 										created_at: {
-											order: "desc",
-										},
+											order: "desc";
+										};
 									},
-								],
+								];
 								_source: {
-									includes: ["shipping_address.street"],
-								},
-								size: 1,
-							},
-						},
-					},
-				},
-			},
-		});
+									includes: ["shipping_address.street"];
+								};
+								size: 1;
+							};
+						};
+					};
+				};
+			}
+		>;
 
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			top_tags: {
 				doc_count_error_upper_bound: number;
 				sum_other_doc_count: number;

--- a/tests/aggregations/metrics/top_metrics.test.ts
+++ b/tests/aggregations/metrics/top_metrics.test.ts
@@ -1,41 +1,36 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import { type ElasticsearchOutput, typedEs } from "../../../src/index";
-import { type CustomIndexes, client } from "../../shared";
+import type { TestAggregationOutput } from "../../shared";
 
 describe("top_metrics Aggregations", () => {
 	test("get the top 10 of a field", () => {
-		const query = typedEs(client, {
-			index: "orders",
-			size: 0,
-			_source: false,
-			aggs: {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
 				max_score: {
 					max: {
-						field: "total",
-					},
-				},
+						field: "total";
+					};
+				};
 				top_scores: {
 					top_metrics: {
 						sort: [
 							{
 								total: {
-									order: "desc",
-								},
+									order: "desc";
+								};
 							},
-						],
+						];
 						metrics: [
 							{
-								field: "total",
+								field: "total";
 							},
-						],
-						size: 10,
-					},
-				},
-			},
-		});
-		type Output = ElasticsearchOutput<typeof query, CustomIndexes>;
-		type Aggregations = Output["aggregations"];
-		expectTypeOf<Aggregations>().toEqualTypeOf<{
+						];
+						size: 10;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			max_score: {
 				value: number;
 				value_as_string?: string;

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -73,6 +73,7 @@ export type TestAggregationOutput<
 	aggregations: ElasticsearchOutput<
 		{
 			index: Index;
+			rest_total_hits_as_int: true;
 			_source: false;
 			size: 0;
 			aggregations: Aggregation;

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -1,5 +1,9 @@
 import type { estypes } from "@elastic/elasticsearch";
-import type { TypedClient } from "../src/index";
+import type {
+	ElasticsearchOutput,
+	TypedClient,
+	TypedSearchRequest,
+} from "../src/index";
 
 export type SearchRequest = estypes.SearchRequest;
 
@@ -60,4 +64,21 @@ export const testQueries = {
 		index: "demo",
 		_source: ["score", "invalid"],
 	} as const satisfies SearchRequest,
+};
+
+export type TestAggregationOutput<
+	Index extends keyof CustomIndexes,
+	Aggregation extends TypedSearchRequest<CustomIndexes>["aggregations"],
+> = {
+	aggregations: ElasticsearchOutput<
+		{
+			index: Index;
+			_source: false;
+			size: 0;
+			aggregations: Aggregation;
+		},
+		CustomIndexes,
+		Index
+	>["aggregations"];
+	input: Aggregation;
 };


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/122

Not convinced of this, we gain 5 line per test, it's nice but it's still a full copy paste between each test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Converted aggregation tests to compile-time type checks using a new helper, removing runtime query construction and simplifying imports.
  - Standardized assertions to focus on aggregation output shapes and input error typing.
- Refactor
  - Harmonized type literals and nested aggregation structures across tests for consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->