### PR TITLE
add ip_range support

### DIFF
--- a/.changeset/two-walls-cheer.md
+++ b/.changeset/two-walls-cheer.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `ip_range` bucket agg support.

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+.changeset/**

--- a/src/aggregations/bucket/ip_range.ts
+++ b/src/aggregations/bucket/ip_range.ts
@@ -1,0 +1,114 @@
+import type {
+	AppendSubAggs,
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	InvalidPropertyTypeInAggregation,
+	SearchRequest,
+	TypeOfField,
+} from "../..";
+import type { AtLeastOneOf, IsSomeSortOf, Prettify } from "../../types/helpers";
+
+type IpRangeSpec =
+	| AtLeastOneOf<
+			{
+				from?: string;
+				to?: string;
+				key?: string;
+			},
+			"from" | "to"
+	  >
+	| {
+			mask: string;
+			key?: string;
+	  };
+
+type FormatToKey<S> = S extends string ? S : undefined extends S ? "*" : never;
+
+type IpRangeOutput<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg extends Record<string, unknown>,
+	Ranges extends readonly IpRangeSpec[],
+> = {
+	[index in keyof Ranges]: Ranges[index] extends {
+		from?: infer F;
+		to?: infer T;
+		mask?: infer M;
+		key?: infer K;
+	}
+		? Prettify<
+				{
+					key: K extends string
+						? K
+						: M extends string
+							? M
+							: `${FormatToKey<F>}-${FormatToKey<T>}`;
+					doc_count: number;
+				} & {
+					[K in "from" as F extends string
+						? K
+						: M extends string
+							? K
+							: never]: M extends string ? string : F;
+				} & {
+					[K in "to" as T extends string
+						? K
+						: M extends string
+							? K
+							: never]: M extends string ? string : T;
+				}
+			> &
+				AppendSubAggs<BaseQuery, E, Index, Agg>
+		: never;
+};
+
+type RangeOutputToObject<Ranges> = Ranges extends readonly { key: string }[]
+	? {
+			[K in Ranges[number] as K["key"]]: Omit<K, "key">;
+		}
+	: never;
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-iprange-aggregation
+export type IpRangeAggs<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	ip_range: {
+		field: infer Field extends string;
+		keyed?: infer Keyed;
+		ranges: infer Ranges;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
+			? Ranges extends readonly IpRangeSpec[]
+				? Keyed extends true
+					? {
+							buckets: RangeOutputToObject<
+								IpRangeOutput<BaseQuery, E, Index, Agg, Ranges>
+							>;
+						}
+					: {
+							// array default (keyed: false)
+							buckets: IpRangeOutput<BaseQuery, E, Index, Agg, Ranges>;
+						}
+				: InvalidPropertyTypeInAggregation<
+						"ranges",
+						Agg,
+						Ranges,
+						Array<IpRangeSpec>
+					>
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					string
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/aggregations/bucket/ip_range.ts
+++ b/src/aggregations/bucket/ip_range.ts
@@ -59,9 +59,8 @@ type IpRangeOutput<
 						: M extends string
 							? K
 							: never]: M extends string ? string : T;
-				}
-			> &
-				AppendSubAggs<BaseQuery, E, Index, Agg>
+				} & AppendSubAggs<BaseQuery, E, Index, Agg>
+			>
 		: never;
 };
 

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -43,9 +43,8 @@ type RangeOutput<
 					[K in "from" as F extends number ? K : never]: F;
 				} & {
 					[K in "to" as T extends number ? K : never]: T;
-				}
-			> &
-				AppendSubAggs<BaseQuery, E, Index, Agg>
+				} & AppendSubAggs<BaseQuery, E, Index, Agg>
+			>
 		: never;
 };
 

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -33,10 +33,11 @@ type RangeOutput<
 	[index in keyof Ranges]: Ranges[index] extends {
 		from?: infer F;
 		to?: infer T;
+		key?: infer K;
 	}
 		? Prettify<
 				{
-					key: `${FormatToKey<F>}-${FormatToKey<T>}`;
+					key: K extends string ? K : `${FormatToKey<F>}-${FormatToKey<T>}`;
 					doc_count: number;
 				} & {
 					[K in "from" as F extends number ? K : never]: F;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,7 @@ import type { FiltersAggs } from "./aggregations/bucket/filters";
 import type { GeoHexGridAggs } from "./aggregations/bucket/geohex_grid";
 import type { GeoTileGridAggs } from "./aggregations/bucket/geotile_grid";
 import type { HistogramAggs } from "./aggregations/bucket/histogram";
+import type { IpRangeAggs } from "./aggregations/bucket/ip_range";
 import type { RangeAggs } from "./aggregations/bucket/range";
 import type { TermsAggs } from "./aggregations/bucket/terms";
 import type { ExtendedStatsAggs } from "./aggregations/metrics/extended_stats";
@@ -180,6 +181,7 @@ export type NextAggsParentKey<
 	| "geohex_grid"
 	| "geotile_grid"
 	| "histogram"
+	| "ip_range"
 	| "median_absolute_deviation"
 	| "percentile_ranks"
 	| "percentiles"
@@ -210,6 +212,8 @@ export type AggregationOutput<
 			| FiltersAggs<BaseQuery, E, Index, Agg>
 			| GeoHexGridAggs<BaseQuery, E, Index, Agg>
 			| GeoTileGridAggs<BaseQuery, E, Index, Agg>
+			| HistogramAggs<BaseQuery, E, Index, Agg>
+			| IpRangeAggs<BaseQuery, E, Index, Agg>
 			| RangeAggs<BaseQuery, E, Index, Agg>
 			| TermsAggs<BaseQuery, E, Index, Agg>
 			//
@@ -218,7 +222,6 @@ export type AggregationOutput<
 			| GeoBoundsAggs<E, Index, Agg>
 			| GeoCentroidAggs<E, Index, Agg>
 			| GeoLineAggs<E, Index, Agg>
-			| HistogramAggs<BaseQuery, E, Index, Agg>
 			| MedianAbsoluteDeviationAggs<E, Index, Agg>
 			| PercentilesAggs<E, Index, Agg>
 			| PercentileRanksAggs<E, Index, Agg>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -76,3 +76,15 @@ export type Enumerate<T extends number, Acc extends number[] = []> = T extends 0
 export type RangeInclusive<T extends number, U extends number> =
 	| U
 	| Exclude<Enumerate<U>, Enumerate<T>>;
+
+export type AtLeastOneOf<
+	T,
+	Keys extends keyof T = keyof T,
+> = Keys extends unknown
+	? Required<Pick<T, Keys>> & Partial<Omit<T, Keys>>
+	: never;
+
+export type Ipv4 = `${number}.${number}.${number}.${number}`;
+export type CirdIpv4 = `${Ipv4}/${number}`;
+export type Ipv6 = string;
+export type CirdIpv6 = `${Ipv6}/${number}`;

--- a/tests/aggregations/bucket/ip_range.test.ts
+++ b/tests/aggregations/bucket/ip_range.test.ts
@@ -1,0 +1,216 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("IpRange Aggregations", () => {
+	test("with from-to", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				ip_ranges: {
+					ip_range: {
+						field: "ip";
+						ranges: [{ to: string }, { from: string }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			ip_ranges: {
+				buckets: [
+					{
+						key: `*-${string}`;
+						to: string;
+						doc_count: number;
+					},
+					{
+						key: `${string}-*`;
+						from: string;
+						doc_count: number;
+					},
+				];
+			};
+		}>();
+	});
+
+	test("with explicit from-to", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				ip_ranges: {
+					ip_range: {
+						field: "ip";
+						ranges: [
+							{ to: "10.0.0.5" },
+							{ from: "10.0.0.5"; to: "10.0.0.255" },
+							{ from: "10.0.0.255" },
+						];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			ip_ranges: {
+				buckets: [
+					{
+						key: "*-10.0.0.5";
+						to: "10.0.0.5";
+						doc_count: number;
+					},
+					{
+						key: "10.0.0.5-10.0.0.255";
+						from: "10.0.0.5";
+						to: "10.0.0.255";
+						doc_count: number;
+					},
+					{
+						key: "10.0.0.255-*";
+						from: "10.0.0.255";
+						doc_count: number;
+					},
+				];
+			};
+		}>();
+	});
+
+	test("with cidr masks", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				ip_ranges: {
+					ip_range: {
+						field: "ip";
+						ranges: [{ mask: "10.0.0.0/25" }, { mask: "10.0.0.127/25" }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			ip_ranges: {
+				buckets: [
+					{
+						key: "10.0.0.0/25";
+						from: string;
+						to: string;
+						doc_count: number;
+					},
+					{
+						key: "10.0.0.127/25";
+						from: string;
+						to: string;
+						doc_count: number;
+					},
+				];
+			};
+		}>();
+	});
+
+	test("with keyed", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				ip_ranges: {
+					ip_range: {
+						field: "ip";
+						ranges: [{ to: "10.0.0.5" }, { from: "10.0.0.5" }];
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			ip_ranges: {
+				buckets: {
+					"*-10.0.0.5": {
+						to: "10.0.0.5";
+						doc_count: number;
+					};
+					"10.0.0.5-*": {
+						from: "10.0.0.5";
+						doc_count: number;
+					};
+				};
+			};
+		}>();
+	});
+	test("with keyed and custom key", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				ip_ranges: {
+					ip_range: {
+						field: "ip";
+						ranges: [
+							{ key: "infinity"; to: "10.0.0.5" },
+							{ key: "and-beyond"; from: "10.0.0.5" },
+						];
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			ip_ranges: {
+				buckets: {
+					infinity: {
+						to: "10.0.0.5";
+						doc_count: number;
+					};
+					"and-beyond": {
+						from: "10.0.0.5";
+						doc_count: number;
+					};
+				};
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				price_ranges: {
+					ip_range: {
+						field: "invalid";
+						keyed: true;
+						ranges: [{ to: "10.0.0.5" }, { from: "10.0.0.5" }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_ranges: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				Aggregations["input"]["price_ranges"]
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid type field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				price_ranges: {
+					ip_range: {
+						field: "score";
+						keyed: true;
+						ranges: [{ to: "10.0.0.5" }, { from: "10.0.0.5" }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_ranges: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["price_ranges"],
+				number,
+				string
+			>;
+		}>();
+	});
+});

--- a/tests/aggregations/bucket/range.test.ts
+++ b/tests/aggregations/bucket/range.test.ts
@@ -127,6 +127,44 @@ describe("Range Aggregations", () => {
 		}>();
 	});
 
+	test("with keyed and custom key", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				price_ranges: {
+					range: {
+						field: "score";
+						keyed: true;
+						ranges: [
+							{ key: "cheap"; to: 100 },
+							{ key: "average"; from: 100; to: 200 },
+							{ key: "expensive"; from: 200 },
+						];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_ranges: {
+				buckets: {
+					cheap: {
+						to: 100.0;
+						doc_count: number;
+					};
+					average: {
+						from: 100.0;
+						to: 200.0;
+						doc_count: number;
+					};
+					expensive: {
+						from: 200.0;
+						doc_count: number;
+					};
+				};
+			};
+		}>();
+	});
+
 	test("fails when using an invalid field", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",

--- a/tests/aggregations/bucket/range.test.ts
+++ b/tests/aggregations/bucket/range.test.ts
@@ -186,4 +186,37 @@ describe("Range Aggregations", () => {
 			>;
 		}>();
 	});
+
+	test("supports nested sub-aggregations in buckets", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
+				with_sub: {
+					range: { field: "shipping_address.geo_point"; ranges: [{ to: 100 }] };
+					aggs: {
+						by_status: { terms: { field: "status" } };
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			with_sub: {
+				buckets: [
+					{
+						key: `*-100.0`;
+						doc_count: number;
+						to: 100.0;
+						by_status: {
+							doc_count_error_upper_bound: number;
+							sum_other_doc_count: number;
+							buckets: Array<{
+								key: "pending" | "completed" | "cancelled";
+								doc_count: number;
+							}>;
+						};
+					},
+				];
+			};
+		}>();
+	});
 });

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -12,6 +12,7 @@ export type CustomIndexes = {
 		score: number;
 		entity_id: string;
 		date: string;
+		ip: `${string}.${string}.${string}.${string}`;
 	};
 	demo2: {
 		invalid: string;


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IP range aggregation support, including CIDR masks, keyed and non-keyed buckets, and custom bucket keys.
  * Enabled custom keys for range aggregation buckets.

* **Tests**
  * Added comprehensive coverage for IP range aggregations, including from/to ranges, CIDR masks, keyed and custom-keyed scenarios, and validation of invalid field/type usage.
  * Expanded tests for range aggregations with keyed custom labels.

* **Chores**
  * Added release metadata documenting a patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->