### PR TITLE
add ip_prefix support

### DIFF
--- a/.changeset/silver-moose-sing.md
+++ b/.changeset/silver-moose-sing.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `ip_prefix` bucket aggregation.

--- a/src/aggregations/bucket/date_range.ts
+++ b/src/aggregations/bucket/date_range.ts
@@ -5,7 +5,7 @@ import type {
 	InvalidFieldInAggregation,
 	SearchRequest,
 } from "../..";
-import type { Prettify } from "../../types/helpers";
+import type { KeyedArrayToObject, Prettify } from "../../types/helpers";
 
 type RangeSpec = {
 	from?: string | undefined;
@@ -46,12 +46,6 @@ type RangeOutput<
 		: never;
 };
 
-type RangeOutputToObject<Ranges> = Ranges extends readonly { key: string }[]
-	? {
-			[K in Ranges[number] as K["key"]]: Omit<K, "key">;
-		}
-	: never;
-
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-daterange-aggregation
 export type DateRangeAggs<
 	BaseQuery extends SearchRequest,
@@ -69,7 +63,7 @@ export type DateRangeAggs<
 		? Ranges extends readonly RangeSpec[]
 			? Keyed extends true
 				? {
-						buckets: RangeOutputToObject<
+						buckets: KeyedArrayToObject<
 							RangeOutput<BaseQuery, E, Index, Agg, Ranges>
 						>;
 					}

--- a/src/aggregations/bucket/ip_prefix.ts
+++ b/src/aggregations/bucket/ip_prefix.ts
@@ -1,0 +1,97 @@
+import type {
+	AppendSubAggs,
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	SearchRequest,
+	TypeOfField,
+} from "../..";
+import type {
+	CidrIpv4,
+	CidrIpv6,
+	Ipv4,
+	Ipv6,
+	IsSomeSortOf,
+	KeyedArrayToObject,
+	PrettyArray,
+} from "../../types/helpers";
+
+type IpPrefixOutput<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg extends Record<string, unknown>,
+	//
+	AppendPrefixLength,
+	PrefixLength extends number,
+	IsIpv6,
+> = PrettyArray<
+	{
+		key: AppendPrefixLength extends true
+			? IsIpv6 extends true
+				? CidrIpv6<PrefixLength>
+				: CidrIpv4<PrefixLength>
+			: IsIpv6 extends true
+				? Ipv6
+				: Ipv4;
+		doc_count: number;
+		is_ipv6: IsIpv6 extends true ? true : false;
+		prefix_length: PrefixLength;
+	} & {
+		[K in "netmask" as IsIpv6 extends true ? never : K]: Ipv4;
+	} & AppendSubAggs<BaseQuery, E, Index, Agg>
+>;
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-ipprefix-aggregation
+export type IpPrefixAggs<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	ip_prefix: {
+		field: infer Field extends string;
+		prefix_length: infer PrefixLength extends number;
+		is_ipv6?: infer IsIpv6; // default: false
+		keyed?: infer Keyed; // default: false
+		append_prefix_length?: infer AppendPrefixLength; // default: false
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
+			? Keyed extends true
+				? {
+						buckets: KeyedArrayToObject<
+							IpPrefixOutput<
+								BaseQuery,
+								E,
+								Index,
+								Agg,
+								AppendPrefixLength,
+								PrefixLength,
+								IsIpv6
+							>
+						>;
+					}
+				: {
+						// array default (keyed: false)
+						buckets: IpPrefixOutput<
+							BaseQuery,
+							E,
+							Index,
+							Agg,
+							AppendPrefixLength,
+							PrefixLength,
+							IsIpv6
+						>;
+					}
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					string
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/aggregations/bucket/ip_range.ts
+++ b/src/aggregations/bucket/ip_range.ts
@@ -8,7 +8,12 @@ import type {
 	SearchRequest,
 	TypeOfField,
 } from "../..";
-import type { AtLeastOneOf, IsSomeSortOf, Prettify } from "../../types/helpers";
+import type {
+	AtLeastOneOf,
+	IsSomeSortOf,
+	KeyedArrayToObject,
+	Prettify,
+} from "../../types/helpers";
 
 type IpRangeSpec =
 	| AtLeastOneOf<
@@ -64,12 +69,6 @@ type IpRangeOutput<
 		: never;
 };
 
-type RangeOutputToObject<Ranges> = Ranges extends readonly { key: string }[]
-	? {
-			[K in Ranges[number] as K["key"]]: Omit<K, "key">;
-		}
-	: never;
-
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-iprange-aggregation
 export type IpRangeAggs<
 	BaseQuery extends SearchRequest,
@@ -88,7 +87,7 @@ export type IpRangeAggs<
 			? Ranges extends readonly IpRangeSpec[]
 				? Keyed extends true
 					? {
-							buckets: RangeOutputToObject<
+							buckets: KeyedArrayToObject<
 								IpRangeOutput<BaseQuery, E, Index, Agg, Ranges>
 							>;
 						}

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -7,6 +7,7 @@ import type {
 } from "../..";
 import type {
 	IsNever,
+	KeyedArrayToObject,
 	Prettify,
 	ToDecimal,
 	ToString,
@@ -48,12 +49,6 @@ type RangeOutput<
 		: never;
 };
 
-type RangeOutputToObject<Ranges> = Ranges extends readonly { key: string }[]
-	? {
-			[K in Ranges[number] as K["key"]]: Omit<K, "key">;
-		}
-	: never;
-
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-range-aggregation
 export type RangeAggs<
 	BaseQuery extends SearchRequest,
@@ -71,7 +66,7 @@ export type RangeAggs<
 		? Ranges extends readonly RangeSpec[]
 			? Keyed extends true
 				? {
-						buckets: RangeOutputToObject<
+						buckets: KeyedArrayToObject<
 							RangeOutput<BaseQuery, E, Index, Agg, Ranges>
 						>;
 					}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,7 @@ import type { FiltersAggs } from "./aggregations/bucket/filters";
 import type { GeoHexGridAggs } from "./aggregations/bucket/geohex_grid";
 import type { GeoTileGridAggs } from "./aggregations/bucket/geotile_grid";
 import type { HistogramAggs } from "./aggregations/bucket/histogram";
+import type { IpPrefixAggs } from "./aggregations/bucket/ip_prefix";
 import type { IpRangeAggs } from "./aggregations/bucket/ip_range";
 import type { RangeAggs } from "./aggregations/bucket/range";
 import type { TermsAggs } from "./aggregations/bucket/terms";
@@ -181,6 +182,7 @@ export type NextAggsParentKey<
 	| "geohex_grid"
 	| "geotile_grid"
 	| "histogram"
+	| "ip_prefix"
 	| "ip_range"
 	| "median_absolute_deviation"
 	| "percentile_ranks"
@@ -213,6 +215,7 @@ export type AggregationOutput<
 			| GeoHexGridAggs<BaseQuery, E, Index, Agg>
 			| GeoTileGridAggs<BaseQuery, E, Index, Agg>
 			| HistogramAggs<BaseQuery, E, Index, Agg>
+			| IpPrefixAggs<BaseQuery, E, Index, Agg>
 			| IpRangeAggs<BaseQuery, E, Index, Agg>
 			| RangeAggs<BaseQuery, E, Index, Agg>
 			| TermsAggs<BaseQuery, E, Index, Agg>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -85,6 +85,12 @@ export type AtLeastOneOf<
 	: never;
 
 export type Ipv4 = `${number}.${number}.${number}.${number}`;
-export type CirdIpv4 = `${Ipv4}/${number}`;
+export type CidrIpv4<T extends number = number> = `${Ipv4}/${T}`;
 export type Ipv6 = string;
-export type CirdIpv6 = `${Ipv6}/${number}`;
+export type CidrIpv6<T extends number = number> = `${Ipv6}/${T}`;
+
+export type KeyedArrayToObject<O> = O extends readonly { key: string }[]
+	? {
+			[K in O[number] as K["key"]]: Omit<K, "key">;
+		}
+	: never;

--- a/tests/aggregations/bucket/ip_prefix.test.ts
+++ b/tests/aggregations/bucket/ip_prefix.test.ts
@@ -1,0 +1,214 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
+import type {
+	CidrIpv4,
+	CidrIpv6,
+	Ipv4,
+	Ipv6,
+} from "../../../src/types/helpers";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("IpPrefix Aggregations", () => {
+	test("default", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				"ipv4-subnets": {
+					ip_prefix: {
+						field: "ip";
+						prefix_length: 24;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			"ipv4-subnets": {
+				buckets: Array<{
+					key: Ipv4;
+					doc_count: number;
+					is_ipv6: false;
+					prefix_length: 24;
+					netmask: Ipv4;
+				}>;
+			};
+		}>();
+	});
+
+	test("with ipv6", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				"ipv6-subnets": {
+					ip_prefix: {
+						field: "ip";
+						prefix_length: 64;
+						is_ipv6: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			"ipv6-subnets": {
+				buckets: Array<{
+					key: Ipv6;
+					doc_count: number;
+					is_ipv6: true;
+					prefix_length: 64;
+				}>;
+			};
+		}>();
+	});
+
+	test("appends prefix length", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				"ipv4-subnets": {
+					ip_prefix: {
+						field: "ip";
+						prefix_length: 24;
+						append_prefix_length: true;
+					};
+				};
+				"ipv6-subnets": {
+					ip_prefix: {
+						field: "ip";
+						prefix_length: 64;
+						append_prefix_length: true;
+						is_ipv6: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			"ipv4-subnets": {
+				buckets: Array<{
+					key: CidrIpv4<24>;
+					doc_count: number;
+					is_ipv6: false;
+					prefix_length: 24;
+					netmask: Ipv4;
+				}>;
+			};
+			"ipv6-subnets": {
+				buckets: Array<{
+					key: CidrIpv6<64>;
+					doc_count: number;
+					is_ipv6: true;
+					prefix_length: 64;
+				}>;
+			};
+		}>();
+	});
+
+	test("with keyed", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				"ipv4-subnets": {
+					ip_prefix: {
+						field: "ip";
+						prefix_length: 24;
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			"ipv4-subnets": {
+				buckets: Record<
+					Ipv4,
+					{
+						is_ipv6: false;
+						prefix_length: 24;
+						netmask: Ipv4;
+						doc_count: number;
+					}
+				>;
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				price_ranges: {
+					ip_prefix: {
+						field: "invalid";
+						prefix_length: 24;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_ranges: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				Aggregations["input"]["price_ranges"]
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid type field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				price_ranges: {
+					ip_prefix: {
+						field: "score";
+						prefix_length: 24;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_ranges: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["price_ranges"],
+				number,
+				string
+			>;
+		}>();
+	});
+
+	test("supports nested sub-aggregations in buckets", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
+				with_sub: {
+					ip_prefix: {
+						field: "shipping_address.geo_point";
+						prefix_length: 24;
+					};
+					aggs: {
+						by_status: { terms: { field: "status" } };
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			with_sub: {
+				buckets: Array<{
+					key: Ipv4;
+					doc_count: number;
+					is_ipv6: false;
+					prefix_length: 24;
+					netmask: Ipv4;
+					by_status: {
+						doc_count_error_upper_bound: number;
+						sum_other_doc_count: number;
+						buckets: Array<{
+							key: "pending" | "completed" | "cancelled";
+							doc_count: number;
+						}>;
+					};
+				}>;
+			};
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for ip_prefix bucket aggregation with typed outputs, including IPv4/IPv6, optional CIDR keys, netmask for IPv4, and nested sub-aggregations.
  - Introduced more precise CIDR typing via parameterized CidrIpv4/CidrIpv6.
- Refactor
  - Unified keyed bucket typing across range, date_range, and ip_range aggregations for consistent keyed results.
- Tests
  - Added comprehensive type-level tests covering ip_prefix scenarios and validation errors.
- Chores
  - Added release entry documenting ip_prefix aggregation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->