### PR TITLE
add boxplot

### DIFF
--- a/.changeset/ready-peas-listen.md
+++ b/.changeset/ready-peas-listen.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `boxplot` metric aggregation.

--- a/src/aggregations/metrics/boxplot.ts
+++ b/src/aggregations/metrics/boxplot.ts
@@ -1,0 +1,39 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
+} from "../..";
+import type { IsSomeSortOf } from "../../types/helpers";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation
+export type BoxplotAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	boxplot: {
+		field: infer Field extends string;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
+			? {
+					min: number;
+					max: number;
+					q1: number;
+					q2: number;
+					q3: number;
+					lower: number;
+					upper: number;
+				}
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					number
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -14,6 +14,7 @@ import type { IpPrefixAggs } from "./aggregations/bucket/ip_prefix";
 import type { IpRangeAggs } from "./aggregations/bucket/ip_range";
 import type { RangeAggs } from "./aggregations/bucket/range";
 import type { TermsAggs } from "./aggregations/bucket/terms";
+import type { BoxplotAggs } from "./aggregations/metrics/boxplot";
 import type { ExtendedStatsAggs } from "./aggregations/metrics/extended_stats";
 import type {
 	AggFunction,
@@ -172,6 +173,7 @@ export type NextAggsParentKey<
 	Aggs = ExtractAggs<Query>,
 > = ObjectKeysWithSpecificKeys<
 	Aggs,
+	| "boxplot"
 	| "date_histogram"
 	| "date_range"
 	| "extended_stats"
@@ -220,6 +222,7 @@ export type AggregationOutput<
 			| RangeAggs<BaseQuery, E, Index, Agg>
 			| TermsAggs<BaseQuery, E, Index, Agg>
 			//
+			| BoxplotAggs<E, Index, Agg>
 			| ExtendedStatsAggs<E, Index, Agg>
 			| FunctionAggs<E, Index, Agg>
 			| GeoBoundsAggs<E, Index, Agg>

--- a/tests/aggregations/metrics/boxplot.test.ts
+++ b/tests/aggregations/metrics/boxplot.test.ts
@@ -1,0 +1,74 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("BoxPlot Aggregations", () => {
+	test("default", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				load_time_boxplot: {
+					boxplot: {
+						field: "load_time";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			load_time_boxplot: {
+				min: number;
+				max: number;
+				q1: number;
+				q2: number;
+				q3: number;
+				lower: number;
+				upper: number;
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field type", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				invalid_stats: {
+					boxplot: {
+						field: "entity_id";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldTypeInAggregation<
+				"entity_id",
+				"demo",
+				Aggregations["input"]["invalid_stats"],
+				string,
+				number
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				invalid_stats: {
+					boxplot: {
+						field: "invalid_field";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldInAggregation<
+				"invalid_field",
+				"demo",
+				Aggregations["input"]["invalid_stats"]
+			>;
+		}>();
+	});
+});

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -13,6 +13,7 @@ export type CustomIndexes = {
 		entity_id: string;
 		date: string;
 		ip: `${string}.${string}.${string}.${string}`;
+		load_time: number;
 	};
 	demo2: {
 		invalid: string;


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added boxplot metric aggregation support, providing min, max, q1, q2 (median), q3, lower, and upper values.
  - Enhanced type safety with compile-time validation that the target field is numeric, with clear error feedback for invalid fields or types.

- Tests
  - Added type-level tests to ensure correct outputs and error typing for boxplot aggregations.

- Chores
  - Patch release published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->