### PR TITLE
matrix_stats

### DIFF
--- a/.changeset/flat-dots-shop.md
+++ b/.changeset/flat-dots-shop.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `matrix_stats` metrics aggregation.

--- a/src/aggregations/metrics/matrix_stats.ts
+++ b/src/aggregations/metrics/matrix_stats.ts
@@ -5,7 +5,7 @@ import type {
 	InvalidFieldTypeInAggregation,
 	TypeOfField,
 } from "../..";
-import type { IsSomeSortOf, Not } from "../../types/helpers";
+import type { IsSomeSortOf, IsStringLiteral, Not } from "../../types/helpers";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-matrix-stats-aggregation
 export type MatrixStatsAggs<
@@ -43,7 +43,11 @@ export type MatrixStatsAggs<
 								kurtosis: number;
 								covariance: Record<Field[number], number>;
 								correlation: {
-									[K in Field[number]]: K extends Field[index] ? 1 : number;
+									[K in Field[number]]: K extends Field[index]
+										? IsStringLiteral<K> extends true
+											? 1
+											: number
+										: number;
 								};
 							};
 			};

--- a/src/aggregations/metrics/matrix_stats.ts
+++ b/src/aggregations/metrics/matrix_stats.ts
@@ -1,0 +1,39 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+} from "../..";
+import type { Not } from "../../types/helpers";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-matrix-stats-aggregation
+export type MatrixStatsAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	matrix_stats: {
+		fields: infer Field extends Array<string>;
+	};
+}
+	? {
+			doc_count: number;
+			fields: {
+				[index in keyof Field]: Not<
+					CanBeUsedInAggregation<Field[index], Index, E>
+				> extends true
+					? InvalidFieldInAggregation<Field[index], Index, Agg>
+					: {
+							name: Field[index];
+							count: number;
+							mean: number;
+							variance: number;
+							skewness: number;
+							kurtosis: number;
+							covariance: Record<Field[number], number>;
+							correlation: {
+								[K in Field[number]]: K extends Field[index] ? 1 : number;
+							};
+						};
+			};
+		}
+	: never;

--- a/src/aggregations/metrics/matrix_stats.ts
+++ b/src/aggregations/metrics/matrix_stats.ts
@@ -2,8 +2,10 @@ import type {
 	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
 	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
 } from "../..";
-import type { Not } from "../../types/helpers";
+import type { IsSomeSortOf, Not } from "../../types/helpers";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-matrix-stats-aggregation
 export type MatrixStatsAggs<
@@ -22,18 +24,28 @@ export type MatrixStatsAggs<
 					CanBeUsedInAggregation<Field[index], Index, E>
 				> extends true
 					? InvalidFieldInAggregation<Field[index], Index, Agg>
-					: {
-							name: Field[index];
-							count: number;
-							mean: number;
-							variance: number;
-							skewness: number;
-							kurtosis: number;
-							covariance: Record<Field[number], number>;
-							correlation: {
-								[K in Field[number]]: K extends Field[index] ? 1 : number;
+					: Not<
+								IsSomeSortOf<TypeOfField<Field[index], E, Index>, number>
+							> extends true
+						? InvalidFieldTypeInAggregation<
+								Field[index],
+								Index,
+								Agg,
+								TypeOfField<Field[index], E, Index>,
+								number
+							>
+						: {
+								name: Field[index];
+								count: number;
+								mean: number;
+								variance: number;
+								skewness: number;
+								kurtosis: number;
+								covariance: Record<Field[number], number>;
+								correlation: {
+									[K in Field[number]]: K extends Field[index] ? 1 : number;
+								};
 							};
-						};
 			};
 		}
 	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -23,6 +23,7 @@ import type {
 import type { GeoBoundsAggs } from "./aggregations/metrics/geo_bounds";
 import type { GeoCentroidAggs } from "./aggregations/metrics/geo_centroid";
 import type { GeoLineAggs } from "./aggregations/metrics/geo_line";
+import type { MatrixStatsAggs } from "./aggregations/metrics/matrix_stats";
 import type { MedianAbsoluteDeviationAggs } from "./aggregations/metrics/median_absolute_deviation";
 import type { PercentileRanksAggs } from "./aggregations/metrics/percentile_ranks";
 import type { PercentilesAggs } from "./aggregations/metrics/percentiles";
@@ -188,6 +189,7 @@ export type NextAggsParentKey<
 	| "histogram"
 	| "ip_prefix"
 	| "ip_range"
+	| "matrix_stats"
 	| "median_absolute_deviation"
 	| "percentile_ranks"
 	| "percentiles"
@@ -232,6 +234,7 @@ export type AggregationOutput<
 			| GeoBoundsAggs<E, Index, Agg>
 			| GeoCentroidAggs<E, Index, Agg>
 			| GeoLineAggs<E, Index, Agg>
+			| MatrixStatsAggs<E, Index, Agg>
 			| MedianAbsoluteDeviationAggs<E, Index, Agg>
 			| PercentilesAggs<E, Index, Agg>
 			| PercentileRanksAggs<E, Index, Agg>

--- a/tests/aggregations/metrics/matrix_stats.test.ts
+++ b/tests/aggregations/metrics/matrix_stats.test.ts
@@ -53,6 +53,35 @@ describe("Matrix Stats Aggregations", () => {
 		}>();
 	});
 
+	test("with non string literal field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				statistics: {
+					matrix_stats: {
+						fields: string[];
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			statistics: {
+				doc_count: number;
+				fields: Array<{
+					name: string;
+					count: number;
+					mean: number;
+					variance: number;
+					skewness: number;
+					kurtosis: number;
+					covariance: Record<string, number>;
+					correlation: Record<string, number>;
+				}>;
+			};
+		}>();
+	});
+
 	test("fails when using an invalid type field", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",

--- a/tests/aggregations/metrics/matrix_stats.test.ts
+++ b/tests/aggregations/metrics/matrix_stats.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Matrix Stats Aggregations", () => {
@@ -42,6 +45,46 @@ describe("Matrix Stats Aggregations", () => {
 						covariance: Record<"price" | "score", number>;
 						correlation: {
 							price: number;
+							score: 1.0;
+						};
+					},
+				];
+			};
+		}>();
+	});
+
+	test("fails when using an invalid type field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				invalid_stats: {
+					matrix_stats: {
+						fields: ["entity_id", "score"];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			invalid_stats: {
+				doc_count: number;
+				fields: [
+					InvalidFieldTypeInAggregation<
+						"entity_id",
+						"demo",
+						Aggregations["input"]["invalid_stats"],
+						string,
+						number
+					>,
+					{
+						name: "score";
+						count: number;
+						mean: number;
+						variance: number;
+						skewness: number;
+						kurtosis: number;
+						covariance: Record<"entity_id" | "score", number>;
+						correlation: {
+							entity_id: number;
 							score: 1.0;
 						};
 					},

--- a/tests/aggregations/metrics/matrix_stats.test.ts
+++ b/tests/aggregations/metrics/matrix_stats.test.ts
@@ -1,0 +1,90 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("Matrix Stats Aggregations", () => {
+	test("default", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				statistics: {
+					matrix_stats: {
+						fields: ["price", "score"];
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			statistics: {
+				doc_count: number;
+				fields: [
+					{
+						name: "price";
+						count: number;
+						mean: number;
+						variance: number;
+						skewness: number;
+						kurtosis: number;
+						covariance: Record<"price" | "score", number>;
+						correlation: {
+							price: 1.0;
+							score: number;
+						};
+					},
+					{
+						name: "score";
+						count: number;
+						mean: number;
+						variance: number;
+						skewness: number;
+						kurtosis: number;
+						covariance: Record<"price" | "score", number>;
+						correlation: {
+							price: number;
+							score: 1.0;
+						};
+					},
+				];
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				invalid_stats: {
+					matrix_stats: {
+						fields: ["invalid", "score"];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			invalid_stats: {
+				doc_count: number;
+				fields: [
+					InvalidFieldInAggregation<
+						"invalid",
+						"demo",
+						Aggregations["input"]["invalid_stats"]
+					>,
+					{
+						name: "score";
+						count: number;
+						mean: number;
+						variance: number;
+						skewness: number;
+						kurtosis: number;
+						covariance: Record<"invalid" | "score", number>;
+						correlation: {
+							invalid: number;
+							score: 1.0;
+						};
+					},
+				];
+			};
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Elasticsearch matrix_stats metrics aggregation, providing typed results for per-field statistics (count, mean, variance, skewness, kurtosis) plus covariance and correlation matrices. Includes compile-time validation for invalid fields and integration into aggregation chaining.
- Tests
  - Added type-level tests covering valid and invalid field scenarios for matrix_stats to ensure accurate output typing and error signaling.
- Chores
  - Added a changeset for a patch release describing the new matrix_stats aggregation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->