### PR TITLE
test for elasticsearch version explicitly

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,6 +28,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    fail-fast: false
     strategy:
       matrix:
         elasticsearch-version: ["^8", "^9"]
@@ -45,6 +46,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    fail-fast: false
     strategy:
       matrix:
         elasticsearch-version: ["^8", "^9"]

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,6 +28,9 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elasticsearch-version: ["^8", "^9"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,11 +38,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      - name: Install Elasticsearch ${{ matrix.elasticsearch-version }}
+        run: bun add @elastic/elasticsearch@"${{ matrix.elasticsearch-version }}" --dev
       - name: Run typecheck
         run: bun run typecheck
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elasticsearch-version: ["^8", "^9"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,5 +55,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      - name: Install Elasticsearch ${{ matrix.elasticsearch-version }}
+        run: bun add @elastic/elasticsearch@"${{ matrix.elasticsearch-version }}" --dev
       - name: Run tests
         run: bun test --coverage


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - CI now runs type checks and tests against Elasticsearch 8 and 9 using a version matrix.
  - The workflow installs the matching Elasticsearch client per matrix entry before executing checks.
  - Build, install, and verification steps remain consistent across versions.
  - No user-facing changes; functionality remains unchanged.
  - No changes to exported/public entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->