### PR TITLE
Cartesian-centroid aggregation

### DIFF
--- a/.changeset/lemon-schools-roll.md
+++ b/.changeset/lemon-schools-roll.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `cartesian_centroid` metric aggregation.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ type CustomIndexes = {
 }
 ```
 
+<details>
+    <summary>For complex types like "point", "shape" even "date" we currently assume that the type is <code>string</code>.</summary>
+
+ex:
+```json
+{
+    "mappings": {
+        "properties": {
+            "location": {
+                "type": "point"
+            },
+            "date": {
+                "type": "date"
+            }
+        }
+    }
+}
+```
+
+would give:
+
+```ts
+type CustomIndexes = {
+	"first-index": {
+		location: string;
+		date: string;
+	};
+};
+```
+
+</details>
+
 ### Step 2: Create a client
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ const myBrokenQuery = typedEs(client, {
     _source: ["score", "entity_id", "*ate"],
 });
 
-const result = await (client as unknown as Client).search(myBrokenQuery); // With the `as Client` cast you are now using the native types
+const result = await (client as unknown as Client).search<TDocument, TAggregations>(myBrokenQuery); // With the `as Client` cast you are now using the native types
 ```
 
 ## Limitations

--- a/src/aggregations/metrics/cartesian_centroid.ts
+++ b/src/aggregations/metrics/cartesian_centroid.ts
@@ -5,7 +5,7 @@ import type {
 	InvalidFieldTypeInAggregation,
 	TypeOfField,
 } from "../..";
-import type { Point, Shape } from "../../types/fields";
+import type { EsPoint, EsShape } from "../../types/fields";
 import type { IsSomeSortOf, Not } from "../../types/helpers";
 
 // https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-centroid-aggregation
@@ -21,14 +21,14 @@ export type CartesianCentroidAggs<
 	? Not<CanBeUsedInAggregation<Field, Index, E>> extends true
 		? InvalidFieldInAggregation<Field, Index, Agg>
 		: Not<
-					IsSomeSortOf<TypeOfField<Field, E, Index>, Point | Shape>
+					IsSomeSortOf<TypeOfField<Field, E, Index>, EsPoint | EsShape>
 				> extends true
 			? InvalidFieldTypeInAggregation<
 					Field,
 					Index,
 					Agg,
 					TypeOfField<Field, E, Index>,
-					Point | Shape
+					EsPoint | EsShape
 				>
 			: {
 					location: {

--- a/src/aggregations/metrics/cartesian_centroid.ts
+++ b/src/aggregations/metrics/cartesian_centroid.ts
@@ -1,0 +1,40 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
+} from "../..";
+import type { Point, Shape } from "../../types/fields";
+import type { IsSomeSortOf, Not } from "../../types/helpers";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-centroid-aggregation
+export type CartesianCentroidAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	cartesian_centroid: {
+		field: infer Field extends string;
+	};
+}
+	? Not<CanBeUsedInAggregation<Field, Index, E>> extends true
+		? InvalidFieldInAggregation<Field, Index, Agg>
+		: Not<
+					IsSomeSortOf<TypeOfField<Field, E, Index>, Point | Shape>
+				> extends true
+			? InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					Point | Shape
+				>
+			: {
+					location: {
+						x: number;
+						y: number;
+					};
+					count: number;
+				}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,6 +15,7 @@ import type { IpRangeAggs } from "./aggregations/bucket/ip_range";
 import type { RangeAggs } from "./aggregations/bucket/range";
 import type { TermsAggs } from "./aggregations/bucket/terms";
 import type { BoxplotAggs } from "./aggregations/metrics/boxplot";
+import type { CartesianCentroidAggs } from "./aggregations/metrics/cartesian_centroid";
 import type { ExtendedStatsAggs } from "./aggregations/metrics/extended_stats";
 import type {
 	AggFunction,
@@ -176,6 +177,7 @@ export type NextAggsParentKey<
 > = ObjectKeysWithSpecificKeys<
 	Aggs,
 	| "boxplot"
+	| "cartesian_centroid"
 	| "date_histogram"
 	| "date_range"
 	| "extended_stats"
@@ -228,6 +230,7 @@ export type AggregationOutput<
 			| TermsAggs<BaseQuery, E, Index, Agg>
 			//
 			| BoxplotAggs<E, Index, Agg>
+			| CartesianCentroidAggs<E, Index, Agg>
 			| ExtendedStatsAggs<E, Index, Agg>
 			| FunctionAggs<E, Index, Agg>
 			| GeoBoundsAggs<E, Index, Agg>

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -1,0 +1,3 @@
+export type Point = string;
+export type Shape = string;
+export type Date = string;

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -1,3 +1,3 @@
-export type Point = string;
-export type Shape = string;
-export type Date = string;
+export type EsPoint = string;
+export type EsShape = string;
+export type EsDate = string;

--- a/tests/aggregations/metrics/cartesian_centroid.test.ts
+++ b/tests/aggregations/metrics/cartesian_centroid.test.ts
@@ -3,6 +3,7 @@ import type {
 	InvalidFieldInAggregation,
 	InvalidFieldTypeInAggregation,
 } from "../../../src/index";
+import type { EsPoint, EsShape } from "../../../src/types/fields";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("CartesianCentroid Aggregations", () => {
@@ -81,7 +82,7 @@ describe("CartesianCentroid Aggregations", () => {
 				"demo",
 				Aggregations["input"]["invalid_stats"],
 				number,
-				string
+				EsPoint | EsShape
 			>;
 		}>();
 	});

--- a/tests/aggregations/metrics/cartesian_centroid.test.ts
+++ b/tests/aggregations/metrics/cartesian_centroid.test.ts
@@ -1,0 +1,109 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("CartesianCentroid Aggregations", () => {
+	test("default", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			// @ts-expect-error - Missing in elasticsearch doc
+			{
+				centroid: {
+					cartesian_centroid: {
+						field: "shipping_address.geo_point";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			centroid: {
+				location: {
+					x: number;
+					y: number;
+				};
+				count: number;
+			};
+		}>();
+	});
+
+	test("inside a terms aggregation", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			// @ts-expect-error - Missing in elasticsearch doc
+			{
+				cities: {
+					terms: { field: "shipping_address.city" };
+					aggs: {
+						centroid: {
+							cartesian_centroid: { field: "shipping_address.geo_point" };
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			cities: {
+				sum_other_doc_count: number;
+				doc_count_error_upper_bound: number;
+				buckets: {
+					key: string | number;
+					doc_count: number;
+					centroid: {
+						location: {
+							x: number;
+							y: number;
+						};
+						count: number;
+					};
+				}[];
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field type", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			// @ts-expect-error - Missing in elasticsearch doc
+			{
+				invalid_stats: {
+					cartesian_centroid: {
+						field: "score";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["invalid_stats"],
+				number,
+				string
+			>;
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			// @ts-expect-error - Missing in elasticsearch doc
+			{
+				invalid_stats: {
+					cartesian_centroid: {
+						field: "invalid_field";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			invalid_stats: InvalidFieldInAggregation<
+				"invalid_field",
+				"demo",
+				Aggregations["input"]["invalid_stats"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the cartesian_centroid metric aggregation with typed results (location x/y and count).
- Documentation
  - Clarified that complex mappings (geo, shape, date) are inferred as strings, with examples.
  - Updated example to show using explicit generics in search calls.
- Tests
  - Added type-level tests for valid outputs, nested usage, and error scenarios.
- Chores
  - Added changeset entry to release a patch documenting the new aggregation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->