### PR TITLE
add support for significant_text aggregation

### DIFF
--- a/.changeset/shaky-dancers-argue.md
+++ b/.changeset/shaky-dancers-argue.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `significant_text` bucket aggregation

--- a/src/aggregations/bucket/significant_text.ts
+++ b/src/aggregations/bucket/significant_text.ts
@@ -1,0 +1,36 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	TypeOfField,
+} from "../..";
+import type { IsSomeSortOf, PrettyArray } from "../../types/helpers";
+
+// https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significanttext-aggregation
+
+export type SignificantTextAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends { significant_text: { field: infer Field extends string } }
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
+			? {
+					doc_count: number;
+					buckets: PrettyArray<{
+						key: string;
+						doc_count: number;
+						score: number;
+						bg_count: number;
+					}>;
+				}
+			: InvalidFieldTypeInAggregation<
+					Field,
+					Index,
+					Agg,
+					TypeOfField<Field, E, Index>,
+					string
+				>
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -13,6 +13,7 @@ import type { HistogramAggs } from "./aggregations/bucket/histogram";
 import type { IpPrefixAggs } from "./aggregations/bucket/ip_prefix";
 import type { IpRangeAggs } from "./aggregations/bucket/ip_range";
 import type { RangeAggs } from "./aggregations/bucket/range";
+import type { SignificantTextAggs } from "./aggregations/bucket/significant_text";
 import type { TermsAggs } from "./aggregations/bucket/terms";
 import type { VariableWidthHistogramAggs } from "./aggregations/bucket/variable_width_histogram";
 import type { BoxplotAggs } from "./aggregations/metrics/boxplot";
@@ -198,6 +199,7 @@ export type NextAggsParentKey<
 	| "range"
 	| "rate"
 	| "scripted_metric"
+	| "significant_text"
 	| "stats"
 	| "string_stats"
 	| "terms"
@@ -229,6 +231,7 @@ export type AggregationOutput<
 			| IpPrefixAggs<BaseQuery, E, Index, Agg>
 			| IpRangeAggs<BaseQuery, E, Index, Agg>
 			| RangeAggs<BaseQuery, E, Index, Agg>
+			| SignificantTextAggs<E, Index, Agg>
 			| TermsAggs<BaseQuery, E, Index, Agg>
 			| VariableWidthHistogramAggs<BaseQuery, E, Index, Agg>
 			//

--- a/tests/aggregations/bucket/significant_text.test.ts
+++ b/tests/aggregations/bucket/significant_text.test.ts
@@ -1,0 +1,76 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("Significant Text Aggregations", () => {
+	test("basic use", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				significant_products: {
+					significant_text: {
+						field: "entity_id";
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			significant_products: {
+				doc_count: number;
+				buckets: Array<{
+					key: string;
+					doc_count: number;
+					score: number;
+					bg_count: number;
+				}>;
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				significant_text_agg: {
+					significant_text: {
+						field: "invalid_field";
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			significant_text_agg: InvalidFieldInAggregation<
+				"invalid_field",
+				"demo",
+				Aggregations["input"]["significant_text_agg"]
+			>;
+		}>();
+	});
+
+	test("failed when using a field that is not a string", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				significant_text_agg: {
+					significant_text: {
+						field: "score";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			significant_text_agg: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["significant_text_agg"],
+				number,
+				string
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
fix: https://github.com/Vahor/typed-es/issues/175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the Significant Text bucket aggregation, including nesting within other aggregations.
  - Enhanced type validation with clear feedback for invalid fields or incompatible field types.
  - Aggregation outputs now include scores and background counts for each bucket.

- Tests
  - Added comprehensive type-level tests covering correct usage and failure cases.

- Chores
  - Published a patch release to deliver the new aggregation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->