### PR TITLE
feat: add support for Change Point pipeline aggregation

### DIFF
--- a/.changeset/eager-singers-spend.md
+++ b/.changeset/eager-singers-spend.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for Change Point pipeline aggregation output types

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Automatically add output types to your Elasticsearch queries.
 | Bucket Correlation | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
 | Bucket Selector | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
 | Bucket Sort | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |
-| Change Point | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
+| Change Point | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
 | Cumulative Cardinality | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation) |
 | Cumulative Sum | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-sum-aggregation) |
 | Derivative | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-derivative-aggregation) |

--- a/src/aggregations/pipeline/change_point.ts
+++ b/src/aggregations/pipeline/change_point.ts
@@ -1,0 +1,39 @@
+/**
+ * Change Point aggregation - detects spikes, dips, and distribution changes in time-based data.
+ *
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation
+ */
+export type ChangePointAggs<Agg> = Agg extends {
+	change_point: {
+		buckets_path: unknown;
+	};
+}
+	? {
+			bucket?: {
+				key: string | number;
+			};
+			type?: {
+				dip?: {
+					p_value: number;
+				};
+				spike?: {
+					p_value: number;
+				};
+				stationary?: Record<string, never>;
+				step_change?: {
+					p_value: number;
+				};
+				distribution_change?: {
+					p_value: number;
+				};
+				trend_change?: {
+					p_value: number;
+					change_point: number;
+				};
+				non_stationary?: {
+					p_value: number;
+					trend?: string;
+				};
+			};
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -47,6 +47,7 @@ import type { StringStatsAggs } from "./aggregations/metrics/string_stats";
 import type { TopHitsAggs } from "./aggregations/metrics/top_hits";
 import type { TopMetricsAggs } from "./aggregations/metrics/top_metrics";
 import type { WeightedAvgAggs } from "./aggregations/metrics/weighted_avg";
+import type { ChangePointAggs } from "./aggregations/pipeline/change_point";
 import type {
 	AnyString,
 	DeepPickPaths,
@@ -276,6 +277,7 @@ export type NextAggsParentKey<
 	| "boxplot"
 	| "cartesian_centroid"
 	| "categorize_text"
+	| "change_point"
 	| "children"
 	| "date_histogram"
 	| "date_range"
@@ -365,6 +367,8 @@ export type AggregationOutput<
 			| TopHitsAggs<BaseQuery, E, Index, Agg>
 			| TopMetricsAggs<E, Index, Agg>
 			| WeightedAvgAggs<E, Index, Agg>
+			//
+			| ChangePointAggs<Agg>
 			//
 			| BucketAggs<Agg>;
 

--- a/tests/aggregations/pipeline/change_point.test.ts
+++ b/tests/aggregations/pipeline/change_point.test.ts
@@ -1,0 +1,51 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type { ChangePointAggs } from "../../../src/aggregations/pipeline/change_point";
+
+describe("Change Point Aggregation", () => {
+	test("output structure for change_point aggregation", () => {
+		type ChangePointOutput = ChangePointAggs<{
+			change_point: {
+				buckets_path: "by_date>total_value";
+			};
+		}>;
+
+		expectTypeOf<ChangePointOutput>().toEqualTypeOf<{
+			bucket?: {
+				key: string | number;
+			};
+			type?: {
+				dip?: {
+					p_value: number;
+				};
+				spike?: {
+					p_value: number;
+				};
+				stationary?: Record<string, never>;
+				step_change?: {
+					p_value: number;
+				};
+				distribution_change?: {
+					p_value: number;
+				};
+				trend_change?: {
+					p_value: number;
+					change_point: number;
+				};
+				non_stationary?: {
+					p_value: number;
+					trend?: string;
+				};
+			};
+		}>();
+	});
+
+	test("returns never when change_point is not present", () => {
+		type NotChangePoint = ChangePointAggs<{
+			stats: {
+				field: "score";
+			};
+		}>;
+
+		expectTypeOf<NotChangePoint>().toEqualTypeOf<never>();
+	});
+});


### PR DESCRIPTION
Add support for the Change Point pipeline aggregation in typed-es output types.
The Change Point aggregation detects spikes, dips, and change points in time-based data.

## Changes
- Created new pipeline aggregations directory structure
- Implemented ChangePointAggs type with full output structure
- Added tests for `change_point` aggregation
- Updated README to mark Change Point as implemented
- Added changeset for patch version

Fixes #245

🤖 Generated with [Claude Code](https://claude.ai/code)