### PR TITLE
feat: add support for cartesian_bounds metric aggregation

### DIFF
--- a/.changeset/cartesian-bounds-aggregation.md
+++ b/.changeset/cartesian-bounds-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `cartesian_bounds` metric aggregation

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Tested with Elasticsearch ^8 and Elasticsearch ^9
 | Avg | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-avg-aggregation) |
 | Boxplot | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation) |
 | Cardinality | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cardinality-aggregation) |
-| Cartesian Bounds | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-bounds-aggregation) |
+| Cartesian Bounds | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-bounds-aggregation) |
 | Cartesian Centroid | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-centroid-aggregation) |
 | Extended Stats | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-extendedstats-aggregation) |
 | Geo Bounds | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geobounds-aggregation) |

--- a/src/aggregations/metrics/cartesian_bounds.ts
+++ b/src/aggregations/metrics/cartesian_bounds.ts
@@ -1,0 +1,33 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+} from "../..";
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-bounds-aggregation
+ */
+export type CartesianBoundsAggs<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	cartesian_bounds: {
+		field: infer Field extends string;
+	};
+}
+	? CanBeUsedInAggregation<Field, Index, E> extends true
+		? {
+				bounds: {
+					top_left: {
+						x: number;
+						y: number;
+					};
+					bottom_right: {
+						x: number;
+						y: number;
+					};
+				};
+			}
+		: InvalidFieldInAggregation<Field, Index, Agg>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -29,6 +29,7 @@ import type { SignificantTextAggs } from "./aggregations/bucket/significant_text
 import type { TermsAggs } from "./aggregations/bucket/terms";
 import type { VariableWidthHistogramAggs } from "./aggregations/bucket/variable_width_histogram";
 import type { BoxplotAggs } from "./aggregations/metrics/boxplot";
+import type { CartesianBoundsAggs } from "./aggregations/metrics/cartesian_bounds";
 import type { CartesianCentroidAggs } from "./aggregations/metrics/cartesian_centroid";
 import type { ExtendedStatsAggs } from "./aggregations/metrics/extended_stats";
 import type {
@@ -276,6 +277,7 @@ export type NextAggsParentKey<
 	| "adjacency_matrix"
 	| "auto_date_histogram"
 	| "boxplot"
+	| "cartesian_bounds"
 	| "cartesian_centroid"
 	| "categorize_text"
 	| "children"
@@ -353,6 +355,7 @@ export type AggregationOutput<
 			| ReverseNestedAggs<BaseQuery, E, Index, Agg>
 			//
 			| BoxplotAggs<E, Index, Agg>
+			| CartesianBoundsAggs<E, Index, Agg>
 			| CartesianCentroidAggs<E, Index, Agg>
 			| ExtendedStatsAggs<E, Index, Agg>
 			| FunctionAggs<E, Index, Agg>

--- a/tests/aggregations/metrics/cartesian_bounds.test.ts
+++ b/tests/aggregations/metrics/cartesian_bounds.test.ts
@@ -1,0 +1,54 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type { InvalidFieldInAggregation } from "../../../src/index";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("CartesianBounds Aggregation", () => {
+	test("simple", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			// @ts-expect-error - Missing in elasticsearch doc
+			{
+				viewport: {
+					cartesian_bounds: {
+						field: "shipping_address.geo_point";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			viewport: {
+				bounds: {
+					top_left: {
+						x: number;
+						y: number;
+					};
+					bottom_right: {
+						x: number;
+						y: number;
+					};
+				};
+			};
+		}>();
+	});
+
+	test("fails when using an invalid field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			// @ts-expect-error - Missing in elasticsearch doc
+			{
+				viewport: {
+					cartesian_bounds: {
+						field: "invalid";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			viewport: InvalidFieldInAggregation<
+				"invalid",
+				"demo",
+				Aggregations["input"]["viewport"]
+			>;
+		}>();
+	});
+});


### PR DESCRIPTION
## Summary

Implements the `cartesian_bounds` metric aggregation for computing spatial bounding boxes in Cartesian coordinate systems.

## Changes

- Add CartesianBoundsAggs type following geo_bounds pattern
- Create test file with base case and invalid field validation
- Update README.md to mark Cartesian Bounds as implemented
- Update lib.ts to include new aggregation in output types
- Add changeset for the new feature

Closes #132

---

Generated with [Claude Code](https://claude.ai/code)