### PR TITLE
feat: add diversified_sampler bucket aggregation

### DIFF
--- a/.changeset/ripe-cups-grow.md
+++ b/.changeset/ripe-cups-grow.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for `diversified_sampler` bucket aggregation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tested with Elasticsearch ^8 and Elasticsearch ^9
 | Composite | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation) |
 | Date Histogram | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation) |
 | Date Range | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-daterange-aggregation) |
-| Diversified Sampler | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-diversified-sampler-aggregation) |
+| Diversified Sampler | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-diversified-sampler-aggregation) |
 | Filter | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filter-aggregation) |
 | Filters | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filters-aggregation) |
 | Frequent Item Sets | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-frequent-item-sets-aggregation) |

--- a/src/aggregations/bucket/diversified_sampler.ts
+++ b/src/aggregations/bucket/diversified_sampler.ts
@@ -1,0 +1,18 @@
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
+import type { Prettify } from "../../types/helpers";
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-diversified-sampler-aggregation
+ */
+export type DiversifiedSamplerAggs<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends { diversified_sampler: object }
+	? Prettify<
+			{
+				doc_count: number;
+			} & AppendSubAggs<BaseQuery, E, Index, Agg>
+		>
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,7 @@ import type { ChildrenAggs } from "./aggregations/bucket/children";
 import type { CompositeAggs } from "./aggregations/bucket/composite";
 import type { DateHistogramAggs } from "./aggregations/bucket/date_histogram";
 import type { DateRangeAggs } from "./aggregations/bucket/date_range";
+import type { DiversifiedSamplerAggs } from "./aggregations/bucket/diversified_sampler";
 import type { FilterAggs } from "./aggregations/bucket/filter";
 import type { FiltersAggs } from "./aggregations/bucket/filters";
 import type { GeoHashGridAggs } from "./aggregations/bucket/geohash_grid";
@@ -284,6 +285,7 @@ export type NextAggsParentKey<
 	| "children"
 	| "date_histogram"
 	| "date_range"
+	| "diversified_sampler"
 	| "extended_stats"
 	| "filter"
 	| "filters"
@@ -337,6 +339,7 @@ export type AggregationOutput<
 			| CompositeAggs<BaseQuery, E, Index, Agg>
 			| DateHistogramAggs<BaseQuery, E, Index, Agg>
 			| DateRangeAggs<BaseQuery, E, Index, Agg>
+			| DiversifiedSamplerAggs<BaseQuery, E, Index, Agg>
 			| FilterAggs<BaseQuery, E, Index, Agg>
 			| FiltersAggs<BaseQuery, E, Index, Agg>
 			| GeoHashGridAggs<BaseQuery, E, Index, Agg>

--- a/tests/aggregations/bucket/diversified_sampler.test.ts
+++ b/tests/aggregations/bucket/diversified_sampler.test.ts
@@ -1,0 +1,97 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("Diversified Sampler Aggregations", () => {
+	test("diversified_sampler without sub-aggregations", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				my_sample: {
+					diversified_sampler: {
+						shard_size: 200;
+						field: "entity_id";
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			my_sample: {
+				doc_count: number;
+			};
+		}>();
+	});
+
+	test("diversified_sampler with terms sub-aggregation (documentation example)", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				my_sample: {
+					diversified_sampler: {
+						shard_size: 200;
+						field: "entity_id";
+					};
+					aggs: {
+						keywords: {
+							significant_text: {
+								field: "entity_id";
+							};
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			my_sample: {
+				doc_count: number;
+				keywords: {
+					doc_count: number;
+					buckets: Array<{
+						key: string;
+						doc_count: number;
+						score: number;
+						bg_count: number;
+					}>;
+				};
+			};
+		}>();
+	});
+
+	test("diversified_sampler with max_docs_per_value", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				my_sample: {
+					diversified_sampler: {
+						shard_size: 200;
+						field: "entity_id";
+						max_docs_per_value: 3;
+					};
+					aggs: {
+						keywords: {
+							significant_text: {
+								field: "entity_id";
+							};
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			my_sample: {
+				doc_count: number;
+				keywords: {
+					doc_count: number;
+					buckets: Array<{
+						key: string;
+						doc_count: number;
+						score: number;
+						bg_count: number;
+					}>;
+				};
+			};
+		}>();
+	});
+});


### PR DESCRIPTION
Add support for the `diversified_sampler` bucket aggregation.

Closes #176

## Changes
- Add DiversifiedSamplerAggs type with support for sub-aggregations
- Add comprehensive test coverage based on Elasticsearch documentation
- Update lib.ts exports and aggregation mappings
- Update README.md to mark as implemented
- Add patch changeset

Generated with [Claude Code](https://claude.ai/code)