### PR TITLE
Add support for optional inner_hits

### DIFF
--- a/.changeset/mighty-snakes-bathe.md
+++ b/.changeset/mighty-snakes-bathe.md
@@ -1,0 +1,7 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for optional `inner_hits` inside `has_child` filters.
+
+Result type will be `{...} | undefined` depending on whether `inner_hits` is present.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -545,19 +545,6 @@ type RecursiveExtractHasChild<Q> =
 				}[keyof Q]
 			: never;
 
-type A = RecursiveExtractHasChild<{
-	query: {
-		bool: {
-			filter: {
-				has_child: {
-					inner_hits: { name: "aa" } | undefined;
-					type: "aa";
-				};
-			}[];
-		};
-	};
-}>;
-
 export type ExtractHasChildInnerHitsKeys<Query extends SearchRequest> =
 	Query extends { query: infer Q } ? RecursiveExtractHasChild<Q> : never;
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -65,7 +65,9 @@ import type {
 	AnyString,
 	DeepPickPaths,
 	IsNever,
+	IsOptional,
 	IsStringLiteral,
+	Optional,
 	RArray,
 	ToString,
 	UnionToIntersection,
@@ -527,17 +529,34 @@ type RecursiveExtractHasChild<Q> =
 		: Q extends Record<string, unknown>
 			? {
 					[K in keyof Q]: K extends "has_child"
-						? Q[K] extends { inner_hits: { name: infer N extends string } }
-							? N
-							: Q[K] extends {
-										inner_hits: NonNullable<unknown>;
+						? Q[K] extends Optional<{
+								inner_hits: { name: infer N extends string };
+							}>
+							? // @ts-expect-error: we can index it
+								{ name: N; optional: IsOptional<Q[K]["inner_hits"]> }
+							: Q[K] extends Optional<{
+										inner_hits: unknown;
 										type: infer T extends string;
-									}
-								? T
+									}>
+								? // @ts-expect-error: we can index it
+									{ name: T; optional: IsOptional<Q[K]["inner_hits"]> }
 								: never
 						: RecursiveExtractHasChild<Q[K]>;
 				}[keyof Q]
 			: never;
+
+type A = RecursiveExtractHasChild<{
+	query: {
+		bool: {
+			filter: {
+				has_child: {
+					inner_hits: { name: "aa" } | undefined;
+					type: "aa";
+				};
+			}[];
+		};
+	};
+}>;
 
 export type ExtractHasChildInnerHitsKeys<Query extends SearchRequest> =
 	Query extends { query: infer Q } ? RecursiveExtractHasChild<Q> : never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -543,19 +543,6 @@ type RecursiveExtractHasChild<Q> =
 				}[keyof Q]
 			: never;
 
-type A = RecursiveExtractHasChild<{
-	query: {
-		bool: {
-			filter: {
-				has_child: {
-					inner_hits: { name: "hello" } | undefined;
-					type: "aa";
-				};
-			}[];
-		};
-	};
-}>;
-
 export type ExtractHasChildInnerHitsKeys<Query extends SearchRequest> =
 	Query extends { query: infer Q } ? RecursiveExtractHasChild<Q> : never;
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -529,21 +529,32 @@ type RecursiveExtractHasChild<Q> =
 		: Q extends Record<string, unknown>
 			? {
 					[K in keyof Q]: K extends "has_child"
-						? Q[K] extends Optional<{
-								inner_hits: { name: infer N extends string };
-							}>
-							? // @ts-expect-error: we can index it
-								{ name: N; optional: IsOptional<Q[K]["inner_hits"]> }
-							: Q[K] extends Optional<{
-										inner_hits: unknown;
+						? Q[K] extends {
+								inner_hits: Optional<{ name: infer N extends string }>;
+							}
+							? { name: N; optional: IsOptional<Q[K]["inner_hits"]> }
+							: Q[K] extends {
+										inner_hits: Optional<unknown>;
 										type: infer T extends string;
-									}>
-								? // @ts-expect-error: we can index it
-									{ name: T; optional: IsOptional<Q[K]["inner_hits"]> }
+									}
+								? { name: T; optional: IsOptional<Q[K]["inner_hits"]> }
 								: never
 						: RecursiveExtractHasChild<Q[K]>;
 				}[keyof Q]
 			: never;
+
+type A = RecursiveExtractHasChild<{
+	query: {
+		bool: {
+			filter: {
+				has_child: {
+					inner_hits: { name: "hello" } | undefined;
+					type: "aa";
+				};
+			}[];
+		};
+	};
+}>;
 
 export type ExtractHasChildInnerHitsKeys<Query extends SearchRequest> =
 	Query extends { query: infer Q } ? RecursiveExtractHasChild<Q> : never;

--- a/src/override/search-response.ts
+++ b/src/override/search-response.ts
@@ -12,7 +12,12 @@ import type {
 	RequestedIndex,
 	SearchRequest,
 } from "../lib";
-import type { IsNever, Prettify, UnionToIntersection } from "../types/helpers";
+import type {
+	IsNever,
+	Optional,
+	Prettify,
+	UnionToIntersection,
+} from "../types/helpers";
 
 type BuildFieldsResult<
 	Query extends SearchRequest,
@@ -70,12 +75,15 @@ type OverrideSearchResponse<
 					inner_hits: IsNever<ExtractHasChildInnerHitsKeys<Query>> extends true
 						? undefined
 						: {
-								[K in ExtractHasChildInnerHitsKeys<Query>]: {
-									hits: {
-										total: InnerHitsQueryTotal<Query>;
-										hits: Array<estypes.SearchHit<unknown>>;
-									};
-								};
+								[K in ExtractHasChildInnerHitsKeys<Query> as K["name"]]: Optional<
+									{
+										hits: {
+											total: InnerHitsQueryTotal<Query>;
+											hits: Array<estypes.SearchHit<unknown>>;
+										};
+									},
+									K["optional"]
+								>;
 							};
 				}
 			>;

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -228,3 +228,9 @@ export type AlternatingPair<
 > = Current["length"] extends Max
 	? Current
 	: Current | AlternatingPair<T1, T2, [...Current, T1, T2], Max>;
+
+export type Optional<T, B extends boolean = true> = B extends true
+	? T | undefined
+	: T;
+
+export type IsOptional<T> = undefined extends T ? true : false;

--- a/tests/reproductions/339.test.ts
+++ b/tests/reproductions/339.test.ts
@@ -1,12 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
 import type { estypes } from "@elastic/elasticsearch";
 import { typedEs } from "../../src";
-import type {
-	TypedMSearchResponse,
-	TypedMsearchRequest,
-} from "../../src/override/msearch-response";
 import type { TypedSearchResponse } from "../../src/override/search-response";
-import { type CustomIndexes, client } from "../shared";
+import { client } from "../shared";
 
 describe("has_child with inner_hits", () => {
 	test("inner_hits keyed by has_child type, total follows rest_total_hits_as_int", () => {

--- a/tests/reproductions/349.test.ts
+++ b/tests/reproductions/349.test.ts
@@ -36,4 +36,37 @@ describe("349", () => {
 				  };
 		}>();
 	});
+	test("has_child with optional inner_hits and custom name", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			rest_total_hits_as_int: true,
+			query: {
+				bool: {
+					filter: {
+						has_child: {
+							type: "aa",
+							query: { match_all: {} },
+							inner_hits: { size: 0, name: "hello" } as
+								| { size: 0; name: "hello" }
+								| undefined,
+						},
+					},
+				},
+			},
+		});
+
+		type Result = TypedSearchResponse<typeof query, never>;
+		type Hit = Result["hits"]["hits"][number];
+
+		expectTypeOf<Hit["inner_hits"]>().toEqualTypeOf<{
+			hello:
+				| undefined
+				| {
+						hits: {
+							total: number;
+							hits: Array<estypes.SearchHit<unknown>>;
+						};
+				  };
+		}>();
+	});
 });

--- a/tests/reproductions/349.test.ts
+++ b/tests/reproductions/349.test.ts
@@ -1,0 +1,39 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type { estypes } from "@elastic/elasticsearch";
+import { typedEs } from "../../src";
+import type { TypedSearchResponse } from "../../src/override/search-response";
+import { client } from "../shared";
+
+describe("349", () => {
+	test("has_child with optional inner_hits", () => {
+		const query = typedEs(client, {
+			index: "demo",
+			rest_total_hits_as_int: true,
+			query: {
+				bool: {
+					filter: {
+						has_child: {
+							type: "aa",
+							query: { match_all: {} },
+							inner_hits: { size: 0 } as { size: 0 } | undefined,
+						},
+					},
+				},
+			},
+		});
+
+		type Result = TypedSearchResponse<typeof query, never>;
+		type Hit = Result["hits"]["hits"][number];
+
+		expectTypeOf<Hit["inner_hits"]>().toEqualTypeOf<{
+			aa:
+				| undefined
+				| {
+						hits: {
+							total: number;
+							hits: Array<estypes.SearchHit<unknown>>;
+						};
+				  };
+		}>();
+	});
+});


### PR DESCRIPTION
closes https://github.com/Vahor/typed-es/issues/349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `inner_hits` configurations within `has_child` filters with accurate TypeScript type inference.

* **Tests**
  * Added test coverage for optional `inner_hits` behavior in child queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->