### PR TITLE
make sure SearchRequest types are available after a typedEs call

### DIFF
--- a/.changeset/extendable-query.md
+++ b/.changeset/extendable-query.md
@@ -2,4 +2,4 @@
 "@vahor/typed-es": patch
 ---
 
-`typedEs` now returns `Query & Omit<estypes.SearchRequest, InferredSearchRequestFields>`, allowing the query object to be extended after creation with any standard Elasticsearch request field (e.g. `timeout`, `size`, `from`).
+`TypedSearchRequest` now includes all standard Elasticsearch request fields (e.g. `timeout`, `size`, `from`), providing autocomplete for any field not overwritten by typed-es. `typedEs` also widens its return type accordingly, so those fields can be assigned after creation.

--- a/.changeset/extendable-query.md
+++ b/.changeset/extendable-query.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+`typedEs` now returns `Query & Omit<estypes.SearchRequest, InferredSearchRequestFields>`, allowing the query object to be extended after creation with any standard Elasticsearch request field (e.g. `timeout`, `size`, `from`).

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -551,7 +551,10 @@ export type InnerHitsQueryTotal<Query extends SearchRequest> =
 		? number
 		: estypes.SearchTotalHits;
 
-export type UsefulSearchRequestFields =
+/**
+ * Fields that are updated by this lib.
+ */
+export type OverwrittenSearchRequestFields =
 	| "_source"
 	| "aggs"
 	| "aggregations"
@@ -560,22 +563,20 @@ export type UsefulSearchRequestFields =
 	| "fields"
 	| "index"
 	| "track_total_hits"
-	| "rest_total_hits_as_int";
+	| "rest_total_hits_as_int"
+	| "sort"
+	| "query";
 
 export type SearchRequest = Pick<
 	estypes.SearchRequest,
-	UsefulSearchRequestFields
+	Exclude<OverwrittenSearchRequestFields, IssueWithReadonlyArray>
 >;
 
 /**
- * Fields omitted from the extendable query return type because `TypedSearchResponse`
- * uses structural key-presence checks on them to determine output types.
- * Adding them as optional fields would corrupt that inference.
+ * HACK: const Query modifier cause sort/query to be readonly. which cause issues with estypes versions as it has mutable arrays in types.
+ * The correct fix would be to overrides these types but as we don't really have to, we simply skip them.
  */
-export type InferredSearchRequestFields =
-	| keyof SearchRequest
-	| "sort" // "sort" extends keyof Query -> hit.sort type
-	| "query"; // Query extends { query: infer Q } -> inner_hits type
+type IssueWithReadonlyArray = "sort" | "query";
 
 /**
  * A type-safe Elasticsearch search request that provides autocomplete and validation
@@ -615,8 +616,8 @@ export type InferredSearchRequestFields =
  * ```
  */
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
-	SearchRequest,
-	"index" | "_source" | "fields" | "docvalue_fields"
+	estypes.SearchRequest,
+	"index" | "_source" | "fields" | "docvalue_fields" | IssueWithReadonlyArray
 > &
 	{
 		[K in keyof Indexes]: {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -568,6 +568,16 @@ export type SearchRequest = Pick<
 >;
 
 /**
+ * Fields omitted from the extendable query return type because `TypedSearchResponse`
+ * uses structural key-presence checks on them to determine output types.
+ * Adding them as optional fields would corrupt that inference.
+ */
+export type InferredSearchRequestFields =
+	| keyof SearchRequest
+	| "sort" // "sort" extends keyof Query -> hit.sort type
+	| "query"; // Query extends { query: infer Q } -> inner_hits type
+
+/**
  * A type-safe Elasticsearch search request that provides autocomplete and validation
  * for index names, _source fields, fields, and docvalue_fields.
  *

--- a/src/typed-es.ts
+++ b/src/typed-es.ts
@@ -1,4 +1,10 @@
-import type { ElasticsearchIndexes, TypedClient, TypedSearchRequest } from ".";
+import type { estypes } from "@elastic/elasticsearch";
+import type {
+	ElasticsearchIndexes,
+	InferredSearchRequestFields,
+	TypedClient,
+	TypedSearchRequest,
+} from ".";
 
 /**
  * Creates a type-safe Elasticsearch search query with automatic type inference for results.
@@ -72,6 +78,10 @@ import type { ElasticsearchIndexes, TypedClient, TypedSearchRequest } from ".";
 export function typedEs<
 	Indexes extends ElasticsearchIndexes,
 	const Query extends TypedSearchRequest<Indexes>,
->(_client: TypedClient<Indexes>, query: Query): Query {
-	return query;
+>(
+	_client: TypedClient<Indexes>,
+	query: Query,
+): Query & Omit<estypes.SearchRequest, InferredSearchRequestFields> {
+	return query as Query &
+		Omit<estypes.SearchRequest, InferredSearchRequestFields>;
 }

--- a/src/typed-es.ts
+++ b/src/typed-es.ts
@@ -1,7 +1,7 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
 	ElasticsearchIndexes,
-	InferredSearchRequestFields,
+	OverwrittenSearchRequestFields,
 	TypedClient,
 	TypedSearchRequest,
 } from ".";
@@ -18,7 +18,7 @@ import type {
  *
  * @param _client - Your TypedClient instance (used for type inference only)
  * @param query - The Elasticsearch search query
- * @returns The same query, but with enhanced type information
+ * @returns The query widened with all standard `estypes.SearchRequest` fields (except `OverwrittenSearchRequestFields`), so fields like `timeout`, `size`, and `from` can be assigned after creation
  *
  * @example
  * ```typescript
@@ -81,7 +81,7 @@ export function typedEs<
 >(
 	_client: TypedClient<Indexes>,
 	query: Query,
-): Query & Omit<estypes.SearchRequest, InferredSearchRequestFields> {
+): Query & Omit<estypes.SearchRequest, OverwrittenSearchRequestFields> {
 	return query as Query &
-		Omit<estypes.SearchRequest, InferredSearchRequestFields>;
+		Omit<estypes.SearchRequest, OverwrittenSearchRequestFields>;
 }

--- a/tests/query-options.test.ts
+++ b/tests/query-options.test.ts
@@ -124,4 +124,13 @@ describe("Query Options", () => {
 			expectTypeOf<Source>().toEqualTypeOf<{}>();
 		});
 	});
+
+	describe("can be extended after creation", () => {
+		test("timeout", () => {
+			const query = typedEs(client, {
+				index: "demo",
+			});
+			query.timeout = "10s";
+		});
+	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `TypedSearchRequest` now includes and supports assignment of standard Elasticsearch request fields such as `timeout`, `size`, and `from` after object creation.

* **Tests**
  * Added test coverage validating post-creation field modification on search requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->