### PR TITLE
Add cumulative sum pipeline aggregation

### DIFF
--- a/.changeset/cumulative-sum-aggregation.md
+++ b/.changeset/cumulative-sum-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for the `cumulative_sum` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npm install -D @vahor/typed-es
 | Bucket Sort | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |
 | Change Point | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
 | Cumulative Cardinality | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation) |
-| Cumulative Sum | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-sum-aggregation) |
+| Cumulative Sum | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-sum-aggregation) |
 | Derivative | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-derivative-aggregation) |
 | Extended Stats Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-extended-stats-bucket-aggregation) |
 | Inference | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-inference-bucket-aggregation) |

--- a/src/aggregations/pipeline/cumulative_sum.ts
+++ b/src/aggregations/pipeline/cumulative_sum.ts
@@ -1,0 +1,11 @@
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-sum-aggregation
+ */
+export type CumulativeSumAggs<Agg> = Agg extends {
+	cumulative_sum: { buckets_path: string };
+}
+	? {
+			value: number;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -54,6 +54,7 @@ import type { TopHitsAggs } from "./aggregations/metrics/top_hits";
 import type { TopMetricsAggs } from "./aggregations/metrics/top_metrics";
 import type { WeightedAvgAggs } from "./aggregations/metrics/weighted_avg";
 import type { AvgBucketAggs } from "./aggregations/pipeline/avg_bucket";
+import type { CumulativeSumAggs } from "./aggregations/pipeline/cumulative_sum";
 import type { ExtendedStatsBucketAggs } from "./aggregations/pipeline/extended_stats_bucket";
 import type { MaxBucketAggs } from "./aggregations/pipeline/max_bucket";
 import type { MinBucketAggs } from "./aggregations/pipeline/min_bucket";
@@ -340,6 +341,7 @@ export type NextAggsParentKey<
 	| AggFunction
 	// Pipeline
 	| "avg_bucket"
+	| "cumulative_sum"
 	| "stats_bucket"
 	| "sum_bucket"
 	| "min_bucket"
@@ -414,6 +416,7 @@ export type AggregationOutput<
 				| WeightedAvgAggs<E, Index, Agg>
 				// Pipeline Aggs
 				| AvgBucketAggs<Agg>
+				| CumulativeSumAggs<Agg>
 				| ExtendedStatsBucketAggs<Agg>
 				| MaxBucketAggs<Agg>
 				| MinBucketAggs<Agg>

--- a/tests/aggregations/pipeline/cumulative_sum.test.ts
+++ b/tests/aggregations/pipeline/cumulative_sum.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 


### PR DESCRIPTION
## Summary
- add typed output support for the `cumulative_sum` pipeline aggregation
- enable the existing cumulative sum aggregation type test
- update the README supported aggregation table
- add a patch changeset

## Notes
- `cumulative_sum` outputs `{ value: number; value_as_string?: string }` and is allowed as a nested pipeline aggregation.

Closes #269