### PR TITLE
Add bucket script aggregation typing

### DIFF
--- a/.changeset/bucket-script-aggregation.md
+++ b/.changeset/bucket-script-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add output typing for the `bucket_script` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npm install -D @vahor/typed-es
 | Aggregation | Status | Documentation |
 |-------------|--------|---------------|
 | Average Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-avg-bucket-aggregation) |
-| Bucket Script | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation) |
+| Bucket Script | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation) |
 | Bucket Count K-S Test | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-count-ks-test-aggregation) |
 | Bucket Correlation | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
 | Bucket Selector | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |

--- a/src/aggregations/pipeline/bucket_script.ts
+++ b/src/aggregations/pipeline/bucket_script.ts
@@ -1,0 +1,14 @@
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation
+ */
+export type BucketScriptAggs<Agg> = Agg extends {
+	bucket_script: {
+		buckets_path: string | string[] | Record<string, string>;
+		script: unknown;
+	};
+}
+	? {
+			value: number;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -54,6 +54,7 @@ import type { TopHitsAggs } from "./aggregations/metrics/top_hits";
 import type { TopMetricsAggs } from "./aggregations/metrics/top_metrics";
 import type { WeightedAvgAggs } from "./aggregations/metrics/weighted_avg";
 import type { AvgBucketAggs } from "./aggregations/pipeline/avg_bucket";
+import type { BucketScriptAggs } from "./aggregations/pipeline/bucket_script";
 import type { CumulativeSumAggs } from "./aggregations/pipeline/cumulative_sum";
 import type { DerivativeAggs } from "./aggregations/pipeline/derivative";
 import type { ExtendedStatsBucketAggs } from "./aggregations/pipeline/extended_stats_bucket";
@@ -342,6 +343,7 @@ export type NextAggsParentKey<
 	| AggFunction
 	// Pipeline
 	| "avg_bucket"
+	| "bucket_script"
 	| "cumulative_sum"
 	| "derivative"
 	| "stats_bucket"
@@ -418,6 +420,7 @@ export type AggregationOutput<
 				| WeightedAvgAggs<E, Index, Agg>
 				// Pipeline Aggs
 				| AvgBucketAggs<Agg>
+				| BucketScriptAggs<Agg>
 				| CumulativeSumAggs<Agg>
 				| DerivativeAggs<Agg>
 				| ExtendedStatsBucketAggs<Agg>

--- a/tests/aggregations/pipeline/bucket_script.test.ts
+++ b/tests/aggregations/pipeline/bucket_script.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 
@@ -41,7 +39,7 @@ describe("Bucket Script Pipeline Aggregation", () => {
 						doc_count: number;
 						sales: { value: number; value_as_string?: string };
 					};
-					"t-shirt-percentage": { value: number };
+					"t-shirt-percentage": { value: number; value_as_string?: string };
 				}>;
 			};
 		}>();


### PR DESCRIPTION
## Summary
- add output typing for the `bucket_script` pipeline aggregation
- enable the existing docs-example type test
- mark Bucket Script as supported in the README
- add a patch changeset

## Notes
- `bucket_script` returns a numeric `value`, with optional `value_as_string` when formatted.

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Elasticsearch `bucket_script` pipeline aggregation with full type-level output typing.

* **Documentation**
  * Updated supported aggregations documentation to reflect `bucket_script` as now supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->