### PR TITLE
Add bucket count K-S test aggregation

### DIFF
--- a/.changeset/bucket-count-ks-test-aggregation.md
+++ b/.changeset/bucket-count-ks-test-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `bucket_count_ks_test` pipeline aggregation output typing.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ npm install -D @vahor/typed-es
 |-------------|--------|---------------|
 | Average Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-avg-bucket-aggregation) |
 | Bucket Script | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation) |
-| Bucket Count K-S Test | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-count-ks-test-aggregation) |
+| Bucket Count K-S Test | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-count-ks-test-aggregation) |
 | Bucket Correlation | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
 | Bucket Selector | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
 | Bucket Sort | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |

--- a/src/aggregations/pipeline/bucket_count_ks_test.ts
+++ b/src/aggregations/pipeline/bucket_count_ks_test.ts
@@ -1,0 +1,20 @@
+import type { Prettify } from "../../types/helpers";
+import type { BucketsPath } from "./types";
+
+type BucketCountKSTestAlternative = "greater" | "less" | "two_sided";
+type BucketCountKSTestOutput<Alternatives> =
+	Alternatives extends readonly BucketCountKSTestAlternative[]
+		? { [K in Alternatives[number]]: number }
+		: { greater: number; less: number; two_sided: number };
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-count-ks-test-aggregation
+ */
+export type BucketCountKSTestAggs<Agg> = Agg extends {
+	bucket_count_ks_test: {
+		buckets_path: BucketsPath;
+		alternative?: infer Alternatives;
+	};
+}
+	? Prettify<BucketCountKSTestOutput<Alternatives>>
+	: never;

--- a/src/aggregations/pipeline/bucket_script.ts
+++ b/src/aggregations/pipeline/bucket_script.ts
@@ -1,9 +1,11 @@
+import type { BucketsPath } from "./types";
+
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation
  */
 export type BucketScriptAggs<Agg> = Agg extends {
 	bucket_script: {
-		buckets_path: string | string[] | Record<string, string>;
+		buckets_path: BucketsPath;
 		script: unknown;
 	};
 }

--- a/src/aggregations/pipeline/types.ts
+++ b/src/aggregations/pipeline/types.ts
@@ -1,0 +1,1 @@
+export type BucketsPath = string | string[] | Record<string, string>;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -54,6 +54,7 @@ import type { TopHitsAggs } from "./aggregations/metrics/top_hits";
 import type { TopMetricsAggs } from "./aggregations/metrics/top_metrics";
 import type { WeightedAvgAggs } from "./aggregations/metrics/weighted_avg";
 import type { AvgBucketAggs } from "./aggregations/pipeline/avg_bucket";
+import type { BucketCountKSTestAggs } from "./aggregations/pipeline/bucket_count_ks_test";
 import type { BucketScriptAggs } from "./aggregations/pipeline/bucket_script";
 import type { CumulativeSumAggs } from "./aggregations/pipeline/cumulative_sum";
 import type { DerivativeAggs } from "./aggregations/pipeline/derivative";
@@ -343,6 +344,7 @@ export type NextAggsParentKey<
 	| AggFunction
 	// Pipeline
 	| "avg_bucket"
+	| "bucket_count_ks_test"
 	| "bucket_script"
 	| "cumulative_sum"
 	| "derivative"
@@ -420,6 +422,7 @@ export type AggregationOutput<
 				| WeightedAvgAggs<E, Index, Agg>
 				// Pipeline Aggs
 				| AvgBucketAggs<Agg>
+				| BucketCountKSTestAggs<Agg>
 				| BucketScriptAggs<Agg>
 				| CumulativeSumAggs<Agg>
 				| DerivativeAggs<Agg>

--- a/tests/aggregations/pipeline/bucket_count_ks_test.test.ts
+++ b/tests/aggregations/pipeline/bucket_count_ks_test.test.ts
@@ -1,31 +1,36 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Bucket Count K-S Test Pipeline Aggregation", () => {
-	test("docs-like example with range buckets", () => {
+	test("docs example: compare latency ranges per version", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",
 			{
 				buckets: {
-					terms: { field: "entity_id"; size: 2 };
+					terms: { field: "version"; size: 2 };
 					aggs: {
-						score_ranges: {
+						latency_ranges: {
 							range: {
-								field: "score";
+								field: "latency";
 								ranges: [
 									{ to: 0 },
-									{ from: 0; to: 10 },
-									{ from: 10; to: 20 },
-									{ from: 20 },
+									{ from: 0; to: 105 },
+									{ from: 105; to: 225 },
+									{ from: 225; to: 445 },
+									{ from: 445; to: 665 },
+									{ from: 665; to: 885 },
+									{ from: 885; to: 1115 },
+									{ from: 1115; to: 1335 },
+									{ from: 1335; to: 1555 },
+									{ from: 1555; to: 1775 },
+									{ from: 1775 },
 								];
 							};
 						};
 						ks_test: {
 							bucket_count_ks_test: {
-								buckets_path: "score_ranges>_count";
-								alternative?: Array<"less" | "greater" | "two_sided">;
+								buckets_path: "latency_ranges>_count";
+								alternative: ["less", "greater", "two_sided"];
 							};
 						};
 					};
@@ -33,26 +38,16 @@ describe("Bucket Count K-S Test Pipeline Aggregation", () => {
 			}
 		>;
 
-		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
-			buckets: {
-				buckets: Array<{
-					key: string | number;
-					doc_count: number;
-					score_ranges: {
-						buckets: Array<{
-							key: string;
-							from?: number;
-							to?: number;
-							doc_count: number;
-						}>;
-					};
-					ks_test: { less?: number; greater?: number; two_sided?: number };
-				}>;
-			};
+		expectTypeOf<
+			Aggregations["aggregations"]["buckets"]["buckets"][number]["ks_test"]
+		>().toEqualTypeOf<{
+			less: number;
+			greater: number;
+			two_sided: number;
 		}>();
 	});
 
-	test("with limited alternatives changes output keys", () => {
+	test("defaults to all alternatives when alternative is omitted", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",
 			{
@@ -72,7 +67,46 @@ describe("Bucket Count K-S Test Pipeline Aggregation", () => {
 						};
 						ks_test: {
 							bucket_count_ks_test: {
-								buckets_path: "score_ranges>_count";
+								buckets_path: ["score_ranges>_count"];
+								fractions: number[];
+								sampling_method: "uniform";
+							};
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<
+			Aggregations["aggregations"]["buckets"]["buckets"][number]["ks_test"]
+		>().toEqualTypeOf<{
+			greater: number;
+			less: number;
+			two_sided: number;
+		}>();
+	});
+
+	test("limits output keys to requested alternatives", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				buckets: {
+					terms: { field: "entity_id"; size: 2 };
+					aggs: {
+						score_ranges: {
+							range: {
+								field: "score";
+								ranges: [
+									{ to: 0 },
+									{ from: 0; to: 10 },
+									{ from: 10; to: 20 },
+									{ from: 20 },
+								];
+							};
+						};
+						ks_test: {
+							bucket_count_ks_test: {
+								buckets_path: { count: "score_ranges>_count" };
 								alternative: ["greater"];
 							};
 						};
@@ -81,22 +115,10 @@ describe("Bucket Count K-S Test Pipeline Aggregation", () => {
 			}
 		>;
 
-		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
-			buckets: {
-				buckets: Array<{
-					key: string | number;
-					doc_count: number;
-					score_ranges: {
-						buckets: Array<{
-							key: string;
-							from?: number;
-							to?: number;
-							doc_count: number;
-						}>;
-					};
-					ks_test: { greater: number };
-				}>;
-			};
+		expectTypeOf<
+			Aggregations["aggregations"]["buckets"]["buckets"][number]["ks_test"]
+		>().toEqualTypeOf<{
+			greater: number;
 		}>();
 	});
 });

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -10,8 +10,10 @@ export type CustomIndexes = {
 		score: number;
 		score_array: Array<number>;
 		entity_id: string;
+		version: string;
 		date: string;
 		ip: `${string}.${string}.${string}.${string}`;
+		latency: number;
 		load_time: number;
 		weight: number;
 		price: number;


### PR DESCRIPTION
## Summary
- add `bucket_count_ks_test` pipeline aggregation output typing
- add docs-based type tests for default and requested alternatives
- mark the aggregation as supported in the README
- add a patch changeset

## Notes
- The output keys are narrowed when `alternative` is specified; omitting it defaults to all K-S alternatives from the Elasticsearch docs.

Closes #241