### PR TITLE
Add bucket correlation aggregation

### DIFF
--- a/.changeset/bucket-correlation-aggregation.md
+++ b/.changeset/bucket-correlation-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add bucket correlation pipeline aggregation output typing.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ npm install -D @vahor/typed-es
 | Average Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-avg-bucket-aggregation) |
 | Bucket Script | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation) |
 | Bucket Count K-S Test | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-count-ks-test-aggregation) |
-| Bucket Correlation | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
+| Bucket Correlation | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
 | Bucket Selector | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
 | Bucket Sort | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |
 | Change Point | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |

--- a/src/aggregations/pipeline/bucket_correlation.ts
+++ b/src/aggregations/pipeline/bucket_correlation.ts
@@ -1,0 +1,23 @@
+import type { Prettify } from "../../types/helpers";
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation
+ */
+export type BucketCorrelationAggs<Agg> = Agg extends {
+	bucket_correlation: {
+		buckets_path: string;
+		function: {
+			count_correlation: {
+				indicator: {
+					doc_count: number;
+					expectations: readonly number[];
+					fractions?: readonly number[];
+				};
+			};
+		};
+	};
+}
+	? Prettify<{
+			value: number;
+		}>
+	: never;

--- a/src/aggregations/pipeline/bucket_correlation.ts
+++ b/src/aggregations/pipeline/bucket_correlation.ts
@@ -4,18 +4,7 @@ import type { Prettify } from "../../types/helpers";
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation
  */
 export type BucketCorrelationAggs<Agg> = Agg extends {
-	bucket_correlation: {
-		buckets_path: string;
-		function: {
-			count_correlation: {
-				indicator: {
-					doc_count: number;
-					expectations: readonly number[];
-					fractions?: readonly number[];
-				};
-			};
-		};
-	};
+	bucket_correlation: unknown;
 }
 	? Prettify<{
 			value: number;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -54,6 +54,7 @@ import type { TopHitsAggs } from "./aggregations/metrics/top_hits";
 import type { TopMetricsAggs } from "./aggregations/metrics/top_metrics";
 import type { WeightedAvgAggs } from "./aggregations/metrics/weighted_avg";
 import type { AvgBucketAggs } from "./aggregations/pipeline/avg_bucket";
+import type { BucketCorrelationAggs } from "./aggregations/pipeline/bucket_correlation";
 import type { BucketCountKSTestAggs } from "./aggregations/pipeline/bucket_count_ks_test";
 import type { BucketScriptAggs } from "./aggregations/pipeline/bucket_script";
 import type { CumulativeSumAggs } from "./aggregations/pipeline/cumulative_sum";
@@ -344,6 +345,7 @@ export type NextAggsParentKey<
 	| AggFunction
 	// Pipeline
 	| "avg_bucket"
+	| "bucket_correlation"
 	| "bucket_count_ks_test"
 	| "bucket_script"
 	| "cumulative_sum"
@@ -422,6 +424,7 @@ export type AggregationOutput<
 				| WeightedAvgAggs<E, Index, Agg>
 				// Pipeline Aggs
 				| AvgBucketAggs<Agg>
+				| BucketCorrelationAggs<Agg>
 				| BucketCountKSTestAggs<Agg>
 				| BucketScriptAggs<Agg>
 				| CumulativeSumAggs<Agg>

--- a/tests/aggregations/pipeline/bucket_correlation.test.ts
+++ b/tests/aggregations/pipeline/bucket_correlation.test.ts
@@ -1,10 +1,70 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Bucket Correlation Pipeline Aggregation", () => {
-	test("docs-like example with range buckets", () => {
+	test("docs example: correlates latency ranges per version", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				buckets: {
+					terms: { field: "version"; size: 2 };
+					aggs: {
+						latency_ranges: {
+							range: {
+								field: "latency";
+								ranges: [
+									{ to: 0 },
+									{ from: 0; to: 105 },
+									{ from: 105; to: 225 },
+									{ from: 225; to: 445 },
+									{ from: 445; to: 665 },
+									{ from: 665; to: 885 },
+									{ from: 885; to: 1115 },
+									{ from: 1115; to: 1335 },
+									{ from: 1335; to: 1555 },
+									{ from: 1555; to: 1775 },
+									{ from: 1775 },
+								];
+							};
+						};
+						bucket_correlation: {
+							bucket_correlation: {
+								buckets_path: "latency_ranges>_count";
+								function: {
+									count_correlation: {
+										indicator: {
+											expectations: [
+												0,
+												52.5,
+												165,
+												335,
+												555,
+												775,
+												1000,
+												1225,
+												1445,
+												1665,
+												1775,
+											];
+											doc_count: 200;
+										};
+									};
+								};
+							};
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<
+			Aggregations["aggregations"]["buckets"]["buckets"][number]["bucket_correlation"]
+		>().toEqualTypeOf<{
+			value: number;
+		}>();
+	});
+
+	test("supports optional indicator fractions", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",
 			{
@@ -22,15 +82,15 @@ describe("Bucket Correlation Pipeline Aggregation", () => {
 								];
 							};
 						};
-						bucket_correlation: {
+						correlation: {
 							bucket_correlation: {
 								buckets_path: "score_ranges>_count";
 								function: {
 									count_correlation: {
 										indicator: {
-											expectations: number[];
-											doc_count: number;
-											fractions?: number[];
+											expectations: [0, 5, 15, 20];
+											doc_count: 100;
+											fractions: [0.25, 0.25, 0.25, 0.25];
 										};
 									};
 								};
@@ -41,22 +101,10 @@ describe("Bucket Correlation Pipeline Aggregation", () => {
 			}
 		>;
 
-		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
-			buckets: {
-				buckets: Array<{
-					key: string | number;
-					doc_count: number;
-					score_ranges: {
-						buckets: Array<{
-							key: string;
-							from?: number;
-							to?: number;
-							doc_count: number;
-						}>;
-					};
-					bucket_correlation: { value: number };
-				}>;
-			};
+		expectTypeOf<
+			Aggregations["aggregations"]["buckets"]["buckets"][number]["correlation"]
+		>().toEqualTypeOf<{
+			value: number;
 		}>();
 	});
 });


### PR DESCRIPTION
## Summary
- add bucket correlation pipeline aggregation output typing
- add docs-based bucket correlation type tests
- mark Bucket Correlation as supported in the README
- add a patch changeset

## Notes
- The output matches the documented response shape: `{ value: number }`.

Closes #242