### PR TITLE
Add normalize pipeline aggregation

### DIFF
--- a/.changeset/normalize-aggregation.md
+++ b/.changeset/normalize-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for the `normalize` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm install -D @vahor/typed-es
 | Min Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-min-bucket-aggregation) |
 | Moving Function | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-movfn-aggregation) |
 | Moving Percentiles | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-moving-percentiles-aggregation) |
-| Normalize | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-normalize-aggregation) |
+| Normalize | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-normalize-aggregation) |
 | Percentiles Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-percentiles-bucket-aggregation) |
 | Serial Differencing | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-serialdiff-aggregation) |
 | Stats Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-stats-bucket-aggregation) |

--- a/src/aggregations/pipeline/normalize.ts
+++ b/src/aggregations/pipeline/normalize.ts
@@ -1,0 +1,24 @@
+import type { BucketsPath } from "./types";
+
+export type NormalizeMethod =
+	| "rescale_0_1"
+	| "rescale_0_100"
+	| "percent_of_sum"
+	| "mean"
+	| "z-score"
+	| "softmax";
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-normalize-aggregation
+ */
+export type NormalizeAggs<Agg> = Agg extends {
+	normalize: {
+		buckets_path: BucketsPath;
+		method: NormalizeMethod;
+	};
+}
+	? {
+			value: number;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -63,6 +63,7 @@ import type { ExtendedStatsBucketAggs } from "./aggregations/pipeline/extended_s
 import type { MaxBucketAggs } from "./aggregations/pipeline/max_bucket";
 import type { MinBucketAggs } from "./aggregations/pipeline/min_bucket";
 import type { MovingPercentilesAggs } from "./aggregations/pipeline/moving_percentiles";
+import type { NormalizeAggs } from "./aggregations/pipeline/normalize";
 import type { PercentilesBucketAggs } from "./aggregations/pipeline/percentiles_bucket";
 import type { StatsBucketAggs } from "./aggregations/pipeline/stats_bucket";
 import type { SumBucketAggs } from "./aggregations/pipeline/sum_bucket";
@@ -355,6 +356,7 @@ export type NextAggsParentKey<
 	| "min_bucket"
 	| "max_bucket"
 	| "extended_stats_bucket"
+	| "normalize"
 	| "percentiles_bucket"
 	| "moving_percentiles"
 >;
@@ -433,6 +435,7 @@ export type AggregationOutput<
 				| MaxBucketAggs<Agg>
 				| MinBucketAggs<Agg>
 				| MovingPercentilesAggs<ExtractAggs<Query>, E, Index, Agg>
+				| NormalizeAggs<Agg>
 				| PercentilesBucketAggs<Agg>
 				| StatsBucketAggs<Agg>
 				| SumBucketAggs<Agg>;

--- a/tests/aggregations/pipeline/normalize.test.ts
+++ b/tests/aggregations/pipeline/normalize.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 
@@ -16,7 +14,7 @@ describe("Normalize Pipeline Aggregation", () => {
 							normalize: {
 								buckets_path: "sales";
 								method: "percent_of_sum";
-								format?: string;
+								format: "00.00%";
 							};
 						};
 					};


### PR DESCRIPTION
## Summary
- add `normalize` pipeline aggregation output typing
- enable the docs-based `normalize` aggregation test
- mark `Normalize` as supported in the README table
- add a patch changeset

## Notes
- `normalize` methods are typed from the Elasticsearch docs: `rescale_0_1`, `rescale_0_100`, `percent_of_sum`, `mean`, `z-score`, and `softmax`.

Closes #278