### PR TITLE
feat: add serial differencing aggregation

### DIFF
--- a/.changeset/serial-differencing-aggregation.md
+++ b/.changeset/serial-differencing-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for the `serial_diff` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ npm install -D @vahor/typed-es
 | Moving Percentiles | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-moving-percentiles-aggregation) |
 | Normalize | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-normalize-aggregation) |
 | Percentiles Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-percentiles-bucket-aggregation) |
-| Serial Differencing | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-serialdiff-aggregation) |
+| Serial Differencing | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-serialdiff-aggregation) |
 | Stats Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-stats-bucket-aggregation) |
 | Sum Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-sum-bucket-aggregation) |
 

--- a/src/aggregations/pipeline/serial_diff.ts
+++ b/src/aggregations/pipeline/serial_diff.ts
@@ -1,0 +1,13 @@
+import type { BucketsPath } from "./types";
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-serialdiff-aggregation
+ */
+export type SerialDiffAggs<Agg> = Agg extends {
+	serial_diff: { buckets_path: BucketsPath };
+}
+	? {
+			value: number;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -65,6 +65,7 @@ import type { MinBucketAggs } from "./aggregations/pipeline/min_bucket";
 import type { MovingPercentilesAggs } from "./aggregations/pipeline/moving_percentiles";
 import type { NormalizeAggs } from "./aggregations/pipeline/normalize";
 import type { PercentilesBucketAggs } from "./aggregations/pipeline/percentiles_bucket";
+import type { SerialDiffAggs } from "./aggregations/pipeline/serial_diff";
 import type { StatsBucketAggs } from "./aggregations/pipeline/stats_bucket";
 import type { SumBucketAggs } from "./aggregations/pipeline/sum_bucket";
 import type {
@@ -359,6 +360,7 @@ export type NextAggsParentKey<
 	| "normalize"
 	| "percentiles_bucket"
 	| "moving_percentiles"
+	| "serial_diff"
 >;
 
 export type AggregationOutput<
@@ -437,6 +439,7 @@ export type AggregationOutput<
 				| MovingPercentilesAggs<ExtractAggs<Query>, E, Index, Agg>
 				| NormalizeAggs<Agg>
 				| PercentilesBucketAggs<Agg>
+				| SerialDiffAggs<Agg>
 				| StatsBucketAggs<Agg>
 				| SumBucketAggs<Agg>;
 

--- a/tests/aggregations/pipeline/serial_diff.test.ts
+++ b/tests/aggregations/pipeline/serial_diff.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 


### PR DESCRIPTION
## Summary
- add `serial_diff` pipeline aggregation output support
- enable the existing serial differencing docs-example type test
- mark Serial Differencing as supported in the README and add a patch changeset

## Notes
- Output includes `value` and optional `value_as_string`, matching the documented `format` response behavior.

Closes #280