### PR TITLE
Add moving function aggregation

### DIFF
--- a/.changeset/moving-function-aggregation.md
+++ b/.changeset/moving-function-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add type support for the `moving_fn` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ npm install -D @vahor/typed-es
 | Inference | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-inference-bucket-aggregation) |
 | Max Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-max-bucket-aggregation) |
 | Min Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-min-bucket-aggregation) |
-| Moving Function | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-movfn-aggregation) |
+| Moving Function | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-movfn-aggregation) |
 | Moving Percentiles | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-moving-percentiles-aggregation) |
 | Normalize | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-normalize-aggregation) |
 | Percentiles Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-percentiles-bucket-aggregation) |

--- a/src/aggregations/pipeline/moving_fn.ts
+++ b/src/aggregations/pipeline/moving_fn.ts
@@ -1,0 +1,17 @@
+import type { BucketsPath } from "./types";
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-movfn-aggregation
+ */
+export type MovingFunctionAggs<Agg> = Agg extends {
+	moving_fn: {
+		buckets_path: BucketsPath;
+		window: number;
+		script: string;
+	};
+}
+	? {
+			value: number | null;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -62,6 +62,7 @@ import type { DerivativeAggs } from "./aggregations/pipeline/derivative";
 import type { ExtendedStatsBucketAggs } from "./aggregations/pipeline/extended_stats_bucket";
 import type { MaxBucketAggs } from "./aggregations/pipeline/max_bucket";
 import type { MinBucketAggs } from "./aggregations/pipeline/min_bucket";
+import type { MovingFunctionAggs } from "./aggregations/pipeline/moving_fn";
 import type { MovingPercentilesAggs } from "./aggregations/pipeline/moving_percentiles";
 import type { NormalizeAggs } from "./aggregations/pipeline/normalize";
 import type { PercentilesBucketAggs } from "./aggregations/pipeline/percentiles_bucket";
@@ -357,6 +358,7 @@ export type NextAggsParentKey<
 	| "min_bucket"
 	| "max_bucket"
 	| "extended_stats_bucket"
+	| "moving_fn"
 	| "normalize"
 	| "percentiles_bucket"
 	| "moving_percentiles"
@@ -436,6 +438,7 @@ export type AggregationOutput<
 				| ExtendedStatsBucketAggs<Agg>
 				| MaxBucketAggs<Agg>
 				| MinBucketAggs<Agg>
+				| MovingFunctionAggs<Agg>
 				| MovingPercentilesAggs<ExtractAggs<Query>, E, Index, Agg>
 				| NormalizeAggs<Agg>
 				| PercentilesBucketAggs<Agg>

--- a/tests/aggregations/pipeline/moving_fn.test.ts
+++ b/tests/aggregations/pipeline/moving_fn.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 
@@ -31,7 +29,7 @@ describe("Moving Function Pipeline Aggregation", () => {
 					key: number;
 					doc_count: number;
 					the_sum: { value: number; value_as_string?: string };
-					the_movfn: { value: number | null };
+					the_movfn: { value: number | null; value_as_string?: string };
 				}>;
 			};
 		}>();


### PR DESCRIPTION
## Summary
- add `moving_fn` pipeline aggregation output typing
- enable the existing `moving_fn` aggregation test against the docs response shape
- mark Moving Function as supported in the README and add a patch changeset

## Notes
- `moving_fn` outputs `value: number | null` because initial buckets can return `null` in the Elasticsearch docs example.

Closes #276