### PR TITLE
Add value_as_string to more aggregation outputs

### DIFF
--- a/.changeset/value-as-string-aggs.md
+++ b/.changeset/value-as-string-aggs.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add optional `value_as_string` fields to additional aggregation response types.

--- a/src/aggregations/metrics/median_absolute_deviation.ts
+++ b/src/aggregations/metrics/median_absolute_deviation.ts
@@ -23,6 +23,7 @@ export type MedianAbsoluteDeviationAggs<
 		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
 			? {
 					value: number;
+					value_as_string?: string;
 				}
 			: InvalidFieldTypeInAggregation<
 					Field,

--- a/src/aggregations/metrics/percentile_ranks.ts
+++ b/src/aggregations/metrics/percentile_ranks.ts
@@ -11,6 +11,7 @@ type PercentilesValues<Percents extends readonly number[]> = {
 	[index in keyof Percents]: {
 		key: ToDecimal<Percents[index]>;
 		value: number;
+		value_as_string?: string;
 	};
 };
 

--- a/src/aggregations/metrics/percentiles.ts
+++ b/src/aggregations/metrics/percentiles.ts
@@ -13,6 +13,7 @@ type PercentilesValues<Percents extends readonly number[]> = {
 	[index in keyof Percents]: {
 		key: ToDecimal<Percents[index]>;
 		value: number;
+		value_as_string?: string;
 	};
 };
 

--- a/src/aggregations/metrics/rate.ts
+++ b/src/aggregations/metrics/rate.ts
@@ -32,5 +32,6 @@ export type RateAggs<
 				>
 			: {
 					value: number;
+					value_as_string?: string;
 				}
 	: never;

--- a/src/aggregations/metrics/t_test.ts
+++ b/src/aggregations/metrics/t_test.ts
@@ -26,6 +26,7 @@ export type TTestAggs<
 				? IsSomeSortOf<TypeOfField<FieldB, E, Index>, number> extends true
 					? {
 							value: number;
+							value_as_string?: string;
 						}
 					: InvalidFieldTypeInAggregation<
 							FieldB,

--- a/src/aggregations/pipeline/bucket_correlation.ts
+++ b/src/aggregations/pipeline/bucket_correlation.ts
@@ -8,5 +8,6 @@ export type BucketCorrelationAggs<Agg> = Agg extends {
 }
 	? Prettify<{
 			value: number;
+			value_as_string?: string;
 		}>
 	: never;

--- a/tests/aggregations/metrics/median_absolute_deviation.test.ts
+++ b/tests/aggregations/metrics/median_absolute_deviation.test.ts
@@ -29,6 +29,7 @@ describe("Median Absolute Deviation Aggregation", () => {
 			};
 			review_variability: {
 				value: number;
+				value_as_string?: string;
 			};
 		}>();
 	});

--- a/tests/aggregations/metrics/percentile_ranks.test.ts
+++ b/tests/aggregations/metrics/percentile_ranks.test.ts
@@ -47,10 +47,12 @@ describe("PercentileRanks Aggregation", () => {
 					{
 						key: "500.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "600.0";
 						value: number;
+						value_as_string?: string;
 					},
 				];
 			};

--- a/tests/aggregations/metrics/percentiles.test.ts
+++ b/tests/aggregations/metrics/percentiles.test.ts
@@ -73,30 +73,37 @@ describe("Percentiles Aggregation", () => {
 					{
 						key: "1.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "5.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "25.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "50.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "75.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "95.0";
 						value: number;
+						value_as_string?: string;
 					},
 					{
 						key: "99.0";
 						value: number;
+						value_as_string?: string;
 					},
 				];
 			};

--- a/tests/aggregations/metrics/rate.test.ts
+++ b/tests/aggregations/metrics/rate.test.ts
@@ -33,6 +33,7 @@ describe("Rate Aggregations", () => {
 					doc_count: number;
 					my_rate: {
 						value: number;
+						value_as_string?: string;
 					};
 				}>;
 			};
@@ -67,6 +68,7 @@ describe("Rate Aggregations", () => {
 					doc_count: number;
 					avg_price: {
 						value: number;
+						value_as_string?: string;
 					};
 				}>;
 			};
@@ -116,6 +118,7 @@ describe("Rate Aggregations", () => {
 					doc_count: number;
 					avg_price: {
 						value: number;
+						value_as_string?: string;
 					};
 				}>;
 			};

--- a/tests/aggregations/metrics/t_test.test.ts
+++ b/tests/aggregations/metrics/t_test.test.ts
@@ -26,6 +26,7 @@ describe("T-Test Aggregation", () => {
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			t_test_result: {
 				value: number;
+				value_as_string?: string;
 			};
 		}>();
 	});
@@ -50,6 +51,7 @@ describe("T-Test Aggregation", () => {
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			my_ttest: {
 				value: number;
+				value_as_string?: string;
 			};
 		}>();
 	});
@@ -74,6 +76,7 @@ describe("T-Test Aggregation", () => {
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			price_diff: {
 				value: number;
+				value_as_string?: string;
 			};
 		}>();
 	});
@@ -97,6 +100,7 @@ describe("T-Test Aggregation", () => {
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			default_test: {
 				value: number;
+				value_as_string?: string;
 			};
 		}>();
 	});
@@ -122,6 +126,7 @@ describe("T-Test Aggregation", () => {
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
 			scripted_test: {
 				value: number;
+				value_as_string?: string;
 			};
 		}>();
 	});

--- a/tests/aggregations/pipeline/bucket_correlation.test.ts
+++ b/tests/aggregations/pipeline/bucket_correlation.test.ts
@@ -61,6 +61,7 @@ describe("Bucket Correlation Pipeline Aggregation", () => {
 			Aggregations["aggregations"]["buckets"]["buckets"][number]["bucket_correlation"]
 		>().toEqualTypeOf<{
 			value: number;
+			value_as_string?: string;
 		}>();
 	});
 
@@ -105,6 +106,7 @@ describe("Bucket Correlation Pipeline Aggregation", () => {
 			Aggregations["aggregations"]["buckets"]["buckets"][number]["correlation"]
 		>().toEqualTypeOf<{
 			value: number;
+			value_as_string?: string;
 		}>();
 	});
 });

--- a/tests/aggregations/pipeline/moving_percentiles.test.ts
+++ b/tests/aggregations/pipeline/moving_percentiles.test.ts
@@ -71,15 +71,15 @@ describe("Moving Percentiles Pipeline Aggregation", () => {
 					doc_count: number;
 					the_percentile: {
 						values: [
-							{ key: "1.0"; value: number },
-							{ key: "99.0"; value: number },
+							{ key: "1.0"; value: number; value_as_string?: string },
+							{ key: "99.0"; value: number; value_as_string?: string },
 						];
 					};
 					the_movperc:
 						| {
 								values: [
-									{ key: "1.0"; value: number },
-									{ key: "99.0"; value: number },
+									{ key: "1.0"; value: number; value_as_string?: string },
+									{ key: "99.0"; value: number; value_as_string?: string },
 								];
 						  }
 						| undefined;


### PR DESCRIPTION
## Summary
- add optional `value_as_string` to additional metric and pipeline aggregation outputs
- update aggregation output type tests for formatted values
- add a patch changeset

## Notes
- Percentiles-style array outputs now include optional `value_as_string` entries, including moving percentiles that inherit percentile output shape.

Closes #100