### PR TITLE
Refactor aggregation field validation

### DIFF
--- a/.changeset/refactor-aggregation-field-validation.md
+++ b/.changeset/refactor-aggregation-field-validation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Refactor aggregation field validation through shared helper types.

--- a/src/aggregations/bucket/auto_date_histogram.ts
+++ b/src/aggregations/bucket/auto_date_histogram.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 } from "../..";
 import type { PrettyArray } from "../../types/helpers";
@@ -20,8 +19,11 @@ export type AutoDateHistogram<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				buckets: PrettyArray<
 					{
 						key_as_string: string;
@@ -30,6 +32,7 @@ export type AutoDateHistogram<
 					} & AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
 				interval: string;
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/auto_date_histogram.ts
+++ b/src/aggregations/bucket/auto_date_histogram.ts
@@ -1,10 +1,6 @@
-import type {
-	AggregationFieldResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-autodatehistogram-aggregation

--- a/src/aggregations/bucket/categorize_text.ts
+++ b/src/aggregations/bucket/categorize_text.ts
@@ -1,13 +1,10 @@
 import type {
+	AggregationFieldTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
 	SearchRequest,
-	TypeOfField,
 } from "../..";
-import type { IsSomeSortOf, PrettyArray } from "../../types/helpers";
+import type { PrettyArray } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-categorize-text-aggregation
@@ -18,24 +15,21 @@ export type CategorizeText<
 	Index extends string,
 	Agg,
 > = Agg extends { categorize_text: { field: infer Field extends string } }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
-			? {
-					buckets: PrettyArray<
-						{
-							key: string;
-							doc_count: number;
-							max_matching_length: number;
-							regex: string;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
-					>;
-				}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					string
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			string,
+			{
+				buckets: PrettyArray<
+					{
+						key: string;
+						doc_count: number;
+						max_matching_length: number;
+						regex: string;
+					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+				>;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/categorize_text.ts
+++ b/src/aggregations/bucket/categorize_text.ts
@@ -1,10 +1,6 @@
-import type {
-	AggregationFieldTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-categorize-text-aggregation

--- a/src/aggregations/bucket/date_histogram.ts
+++ b/src/aggregations/bucket/date_histogram.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 } from "../..";
 import type { PrettyArray } from "../../types/helpers";
@@ -21,27 +20,31 @@ export type DateHistogram<
 		keyed?: infer Keyed;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? Keyed extends true
-			? {
-					buckets: Record<
-						string,
-						{
-							key_as_string: string;
-							key: number;
-							doc_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
-					>;
-				}
-			: // array default (keyed: false)
-				{
-					buckets: PrettyArray<
-						{
-							key_as_string: string;
-							key: number;
-							doc_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
-					>;
-				}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			Keyed extends true
+				? {
+						buckets: Record<
+							string,
+							{
+								key_as_string: string;
+								key: number;
+								doc_count: number;
+							} & AppendSubAggs<BaseQuery, E, Index, Agg>
+						>;
+					}
+				: // array default (keyed: false)
+					{
+						buckets: PrettyArray<
+							{
+								key_as_string: string;
+								key: number;
+								doc_count: number;
+							} & AppendSubAggs<BaseQuery, E, Index, Agg>
+						>;
+					},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/date_histogram.ts
+++ b/src/aggregations/bucket/date_histogram.ts
@@ -1,10 +1,6 @@
-import type {
-	AggregationFieldResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation

--- a/src/aggregations/bucket/date_range.ts
+++ b/src/aggregations/bucket/date_range.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 } from "../..";
 import type { KeyedArrayToObject, Prettify } from "../../types/helpers";
@@ -61,18 +60,22 @@ export type DateRange<
 		ranges: infer Ranges;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? Ranges extends readonly RangeSpec[]
-			? Keyed extends true
-				? {
-						buckets: KeyedArrayToObject<
-							RangeOutput<BaseQuery, E, Index, Agg, Ranges>
-						>;
-					}
-				: {
-						// array default (keyed: false)
-						buckets: RangeOutput<BaseQuery, E, Index, Agg, Ranges>;
-					}
-			: never
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			Ranges extends readonly RangeSpec[]
+				? Keyed extends true
+					? {
+							buckets: KeyedArrayToObject<
+								RangeOutput<BaseQuery, E, Index, Agg, Ranges>
+							>;
+						}
+					: {
+							// array default (keyed: false)
+							buckets: RangeOutput<BaseQuery, E, Index, Agg, Ranges>;
+						}
+				: never,
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/date_range.ts
+++ b/src/aggregations/bucket/date_range.ts
@@ -1,10 +1,6 @@
-import type {
-	AggregationFieldResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { KeyedArrayToObject, Prettify } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 type RangeSpec = {
 	from?: string | undefined;

--- a/src/aggregations/bucket/geohash_grid.ts
+++ b/src/aggregations/bucket/geohash_grid.ts
@@ -1,16 +1,11 @@
 import type {
+	AggregationFieldResult,
+	AggregationPropertyTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidPropertyTypeInAggregation,
 	SearchRequest,
 } from "../..";
-import type {
-	IsSomeSortOf,
-	PrettyArray,
-	RangeInclusive,
-} from "../../types/helpers";
+import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 
 type DefaultPrecision = 5;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;
@@ -30,21 +25,25 @@ export type GeoHashGrid<
 		precision?: infer Precision;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<GetPrecision<Precision>, Range_1_12> extends true
-			? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			AggregationPropertyTypeResult<
+				"precision",
+				Agg,
+				Precision,
+				Range_1_12,
+				{
 					buckets: PrettyArray<
 						{
 							key: string;
 							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
-				}
-			: InvalidPropertyTypeInAggregation<
-					"precision",
-					Agg,
-					Precision,
-					Range_1_12
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+				},
+				GetPrecision<Precision>
+			>,
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/geohash_grid.ts
+++ b/src/aggregations/bucket/geohash_grid.ts
@@ -1,11 +1,9 @@
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
+import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 import type {
 	AggregationFieldResult,
 	AggregationPropertyTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
-import type { PrettyArray, RangeInclusive } from "../../types/helpers";
+} from "../helpers";
 
 type DefaultPrecision = 5;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;

--- a/src/aggregations/bucket/geohex_grid.ts
+++ b/src/aggregations/bucket/geohex_grid.ts
@@ -1,16 +1,11 @@
 import type {
+	AggregationFieldResult,
+	AggregationPropertyTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidPropertyTypeInAggregation,
 	SearchRequest,
 } from "../..";
-import type {
-	IsSomeSortOf,
-	PrettyArray,
-	RangeInclusive,
-} from "../../types/helpers";
+import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 
 type DefaultPrecision = 6;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;
@@ -30,21 +25,25 @@ export type GeoHexGrid<
 		precision?: infer Precision;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<GetPrecision<Precision>, Range_0_15> extends true
-			? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			AggregationPropertyTypeResult<
+				"precision",
+				Agg,
+				Precision,
+				Range_0_15,
+				{
 					buckets: PrettyArray<
 						{
 							key: string;
 							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
-				}
-			: InvalidPropertyTypeInAggregation<
-					"precision",
-					Agg,
-					Precision,
-					Range_0_15
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+				},
+				GetPrecision<Precision>
+			>,
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/geohex_grid.ts
+++ b/src/aggregations/bucket/geohex_grid.ts
@@ -1,11 +1,9 @@
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
+import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 import type {
 	AggregationFieldResult,
 	AggregationPropertyTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
-import type { PrettyArray, RangeInclusive } from "../../types/helpers";
+} from "../helpers";
 
 type DefaultPrecision = 6;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;

--- a/src/aggregations/bucket/geotile_grid.ts
+++ b/src/aggregations/bucket/geotile_grid.ts
@@ -1,11 +1,9 @@
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
+import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 import type {
 	AggregationFieldResult,
 	AggregationPropertyTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
-import type { PrettyArray, RangeInclusive } from "../../types/helpers";
+} from "../helpers";
 
 type DefaultPrecision = 7;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;

--- a/src/aggregations/bucket/geotile_grid.ts
+++ b/src/aggregations/bucket/geotile_grid.ts
@@ -1,16 +1,11 @@
 import type {
+	AggregationFieldResult,
+	AggregationPropertyTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidPropertyTypeInAggregation,
 	SearchRequest,
 } from "../..";
-import type {
-	IsSomeSortOf,
-	PrettyArray,
-	RangeInclusive,
-} from "../../types/helpers";
+import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 
 type DefaultPrecision = 7;
 type GetPrecision<P> = P extends number ? P : DefaultPrecision;
@@ -30,21 +25,25 @@ export type GeoTileGrid<
 		precision?: infer Precision;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<GetPrecision<Precision>, Range_0_29> extends true
-			? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			AggregationPropertyTypeResult<
+				"precision",
+				Agg,
+				Precision,
+				Range_0_29,
+				{
 					buckets: PrettyArray<
 						{
 							key: `${GetPrecision<Precision>}/${number}/${number}`;
 							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
-				}
-			: InvalidPropertyTypeInAggregation<
-					"precision",
-					Agg,
-					Precision,
-					Range_0_29
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+				},
+				GetPrecision<Precision>
+			>,
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/histogram.ts
+++ b/src/aggregations/bucket/histogram.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 } from "../..";
 
@@ -31,17 +30,21 @@ export type Histogram<
 		keyed?: infer Keyed;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? Keyed extends true
-			? {
-					buckets: Record<
-						`${number}`,
-						HistogramAggOutput<BaseQuery, E, Index, Agg>
-					>;
-				}
-			: {
-					// array default (keyed: false)
-					buckets: Array<HistogramAggOutput<BaseQuery, E, Index, Agg>>;
-				}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			Keyed extends true
+				? {
+						buckets: Record<
+							`${number}`,
+							HistogramAggOutput<BaseQuery, E, Index, Agg>
+						>;
+					}
+				: {
+						// array default (keyed: false)
+						buckets: Array<HistogramAggOutput<BaseQuery, E, Index, Agg>>;
+					},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/histogram.ts
+++ b/src/aggregations/bucket/histogram.ts
@@ -1,9 +1,5 @@
-import type {
-	AggregationFieldResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 type HistogramAggOutput<
 	BaseQuery extends SearchRequest,

--- a/src/aggregations/bucket/ip_prefix.ts
+++ b/src/aggregations/bucket/ip_prefix.ts
@@ -1,18 +1,14 @@
 import type {
+	AggregationFieldTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
 	SearchRequest,
-	TypeOfField,
 } from "../..";
 import type {
 	CidrIpv4,
 	CidrIpv6,
 	Ipv4,
 	Ipv6,
-	IsSomeSortOf,
 	KeyedArrayToObject,
 	PrettyArray,
 } from "../../types/helpers";
@@ -60,9 +56,12 @@ export type IpPrefix<
 		append_prefix_length?: infer AppendPrefixLength; // default: false
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
-			? Keyed extends true
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			string,
+			Keyed extends true
 				? {
 						buckets: KeyedArrayToObject<
 							IpPrefixOutput<
@@ -87,13 +86,7 @@ export type IpPrefix<
 							PrefixLength,
 							IsIpv6
 						>;
-					}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					string
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+					},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/ip_prefix.ts
+++ b/src/aggregations/bucket/ip_prefix.ts
@@ -1,9 +1,4 @@
-import type {
-	AggregationFieldTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type {
 	CidrIpv4,
 	CidrIpv6,
@@ -12,6 +7,7 @@ import type {
 	KeyedArrayToObject,
 	PrettyArray,
 } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 type IpPrefixOutput<
 	BaseQuery extends SearchRequest,

--- a/src/aggregations/bucket/ip_range.ts
+++ b/src/aggregations/bucket/ip_range.ts
@@ -1,16 +1,12 @@
 import type {
+	AggregationFieldTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
 	InvalidPropertyTypeInAggregation,
 	SearchRequest,
-	TypeOfField,
 } from "../..";
 import type {
 	AtLeastOneOf,
-	IsSomeSortOf,
 	KeyedArrayToObject,
 	Prettify,
 } from "../../types/helpers";
@@ -84,9 +80,12 @@ export type IpRange<
 		ranges: infer Ranges;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
-			? Ranges extends readonly IpRangeSpec[]
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			string,
+			Ranges extends readonly IpRangeSpec[]
 				? Keyed extends true
 					? {
 							buckets: KeyedArrayToObject<
@@ -102,13 +101,7 @@ export type IpRange<
 						Agg,
 						Ranges,
 						Array<IpRangeSpec>
-					>
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					string
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+					>,
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/ip_range.ts
+++ b/src/aggregations/bucket/ip_range.ts
@@ -1,5 +1,4 @@
 import type {
-	AggregationFieldTypeResult,
 	AppendSubAggs,
 	ElasticsearchIndexes,
 	InvalidPropertyTypeInAggregation,
@@ -10,6 +9,7 @@ import type {
 	KeyedArrayToObject,
 	Prettify,
 } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 type IpRangeSpec =
 	| AtLeastOneOf<

--- a/src/aggregations/bucket/multi_terms.ts
+++ b/src/aggregations/bucket/multi_terms.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 	TypeOfField,
 } from "../../";
@@ -20,8 +19,11 @@ export type MultiTerms<
 	multi_terms: { terms: infer Terms extends Array<object> };
 }
 	? Terms extends { field: infer Field extends string }[]
-		? CanBeUsedInAggregation<Field, Index, E> extends true
-			? {
+		? AggregationFieldResult<
+				E,
+				Index,
+				Agg,
+				{
 					doc_count_error_upper_bound: number;
 					sum_other_doc_count: number;
 					buckets: PrettyArray<
@@ -31,7 +33,8 @@ export type MultiTerms<
 							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
-				}
-			: InvalidFieldInAggregation<Field, Index, Agg>
+				},
+				Field
+			>
 		: never
 	: never;

--- a/src/aggregations/bucket/multi_terms.ts
+++ b/src/aggregations/bucket/multi_terms.ts
@@ -1,11 +1,11 @@
 import type {
-	AggregationFieldResult,
 	AppendSubAggs,
 	ElasticsearchIndexes,
 	SearchRequest,
 	TypeOfField,
 } from "../../";
 import type { PrettyArray, SeparatedString } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-multi-terms-aggregation

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 } from "../..";
 import type {
@@ -65,18 +64,22 @@ export type Range<
 		ranges: infer Ranges;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? Ranges extends readonly RangeSpec[]
-			? Keyed extends true
-				? {
-						buckets: KeyedArrayToObject<
-							RangeOutput<BaseQuery, E, Index, Agg, Ranges>
-						>;
-					}
-				: {
-						// array default (keyed: false)
-						buckets: RangeOutput<BaseQuery, E, Index, Agg, Ranges>;
-					}
-			: never
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			Ranges extends readonly RangeSpec[]
+				? Keyed extends true
+					? {
+							buckets: KeyedArrayToObject<
+								RangeOutput<BaseQuery, E, Index, Agg, Ranges>
+							>;
+						}
+					: {
+							// array default (keyed: false)
+							buckets: RangeOutput<BaseQuery, E, Index, Agg, Ranges>;
+						}
+				: never,
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -1,9 +1,4 @@
-import type {
-	AggregationFieldResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type {
 	IsNever,
 	KeyedArrayToObject,
@@ -11,6 +6,7 @@ import type {
 	ToDecimal,
 	ToString,
 } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 type RangeSpec = {
 	from?: number | undefined;

--- a/src/aggregations/bucket/rare_terms.ts
+++ b/src/aggregations/bucket/rare_terms.ts
@@ -1,11 +1,11 @@
 import type {
-	AggregationFieldResult,
 	AppendSubAggs,
 	ElasticsearchIndexes,
 	SearchRequest,
 	TypeOfField,
 } from "../..";
 import type { IsStringLiteral, PrettyArray } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-rare-terms-aggregation

--- a/src/aggregations/bucket/rare_terms.ts
+++ b/src/aggregations/bucket/rare_terms.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 	TypeOfField,
 } from "../..";
@@ -17,8 +16,11 @@ export type RareTerms<
 	Index extends string,
 	Agg,
 > = Agg extends { rare_terms: { field: infer Field extends string } }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				buckets: PrettyArray<
 					{
 						// TODO: should probably add a helper for this kind of thing
@@ -30,6 +32,7 @@ export type RareTerms<
 						doc_count: number;
 					} & AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/significant_terms.ts
+++ b/src/aggregations/bucket/significant_terms.ts
@@ -1,13 +1,10 @@
 import type {
+	AggregationFieldTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
 	SearchRequest,
-	TypeOfField,
 } from "../../";
-import type { IsSomeSortOf, PrettyArray } from "../../types/helpers";
+import type { PrettyArray } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significantterms-aggregation
@@ -18,26 +15,23 @@ export type SignificantTerms<
 	Index extends string,
 	Agg,
 > = Agg extends { significant_terms: { field: infer Field extends string } }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
-			? {
-					doc_count: number;
-					bg_count: number;
-					buckets: PrettyArray<
-						{
-							key: string;
-							doc_count: number;
-							score: number;
-							bg_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
-					>;
-				}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					string
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			string,
+			{
+				doc_count: number;
+				bg_count: number;
+				buckets: PrettyArray<
+					{
+						key: string;
+						doc_count: number;
+						score: number;
+						bg_count: number;
+					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+				>;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/significant_terms.ts
+++ b/src/aggregations/bucket/significant_terms.ts
@@ -1,10 +1,10 @@
 import type {
-	AggregationFieldTypeResult,
 	AppendSubAggs,
 	ElasticsearchIndexes,
 	SearchRequest,
 } from "../../";
 import type { PrettyArray } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significantterms-aggregation

--- a/src/aggregations/bucket/significant_text.ts
+++ b/src/aggregations/bucket/significant_text.ts
@@ -1,10 +1,6 @@
-import type {
-	AggregationFieldTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significanttext-aggregation

--- a/src/aggregations/bucket/significant_text.ts
+++ b/src/aggregations/bucket/significant_text.ts
@@ -1,13 +1,10 @@
 import type {
+	AggregationFieldTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
 	SearchRequest,
-	TypeOfField,
 } from "../..";
-import type { IsSomeSortOf, PrettyArray } from "../../types/helpers";
+import type { PrettyArray } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significanttext-aggregation
@@ -18,25 +15,22 @@ export type SignificantText<
 	Index extends string,
 	Agg,
 > = Agg extends { significant_text: { field: infer Field extends string } }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
-			? {
-					doc_count: number;
-					buckets: PrettyArray<
-						{
-							key: string;
-							doc_count: number;
-							score: number;
-							bg_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
-					>;
-				}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					string
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			string,
+			{
+				doc_count: number;
+				buckets: PrettyArray<
+					{
+						key: string;
+						doc_count: number;
+						score: number;
+						bg_count: number;
+					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+				>;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/terms.ts
+++ b/src/aggregations/bucket/terms.ts
@@ -1,11 +1,11 @@
 import type {
-	AggregationFieldResult,
 	AppendSubAggs,
 	ElasticsearchIndexes,
 	SearchRequest,
 	TypeOfField,
 } from "../..";
 import type { IsStringLiteral, PrettyArray } from "../../types/helpers";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-terms-aggregation

--- a/src/aggregations/bucket/terms.ts
+++ b/src/aggregations/bucket/terms.ts
@@ -1,8 +1,7 @@
 import type {
+	AggregationFieldResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	SearchRequest,
 	TypeOfField,
 } from "../..";
@@ -17,8 +16,11 @@ export type Terms<
 	Index extends string,
 	Agg,
 > = Agg extends { terms: { field: infer Field extends string } }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				doc_count_error_upper_bound: number;
 				sum_other_doc_count: number;
 				buckets: PrettyArray<
@@ -31,6 +33,7 @@ export type Terms<
 						doc_count: number;
 					} & AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/variable_width_histogram.ts
+++ b/src/aggregations/bucket/variable_width_histogram.ts
@@ -1,13 +1,10 @@
 import type {
+	AggregationFieldTypeResult,
 	AppendSubAggs,
-	CanBeUsedInAggregation,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
 	SearchRequest,
-	TypeOfField,
 } from "../..";
-import type { AtMostN, IsSomeSortOf, Not, Prettify } from "../../types/helpers";
+import type { AtMostN, Prettify } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-variablewidthhistogram-aggregation
@@ -23,27 +20,24 @@ export type VariableWidthHistogram<
 		buckets: infer Buckets extends number;
 	};
 }
-	? Not<CanBeUsedInAggregation<Field, Index, E>> extends true
-		? InvalidFieldInAggregation<Field, Index, Agg>
-		: Not<IsSomeSortOf<TypeOfField<Field, E, Index>, number>> extends true
-			? InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					number
-				>
-			: {
-					buckets: AtMostN<
-						Prettify<
-							{
-								min: number;
-								key: number;
-								max: number;
-								doc_count: number;
-							} & AppendSubAggs<BaseQuery, E, Index, Agg>
-						>,
-						Buckets
-					>;
-				}
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			{
+				buckets: AtMostN<
+					Prettify<
+						{
+							min: number;
+							key: number;
+							max: number;
+							doc_count: number;
+						} & AppendSubAggs<BaseQuery, E, Index, Agg>
+					>,
+					Buckets
+				>;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/bucket/variable_width_histogram.ts
+++ b/src/aggregations/bucket/variable_width_histogram.ts
@@ -1,10 +1,6 @@
-import type {
-	AggregationFieldTypeResult,
-	AppendSubAggs,
-	ElasticsearchIndexes,
-	SearchRequest,
-} from "../..";
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { AtMostN, Prettify } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-variablewidthhistogram-aggregation

--- a/src/aggregations/helpers.ts
+++ b/src/aggregations/helpers.ts
@@ -1,0 +1,122 @@
+import type {
+	CanBeUsedInAggregation,
+	ElasticsearchIndexes,
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+	InvalidPropertyTypeInAggregation,
+	TypeOfField,
+} from "../lib";
+import type { IsSomeSortOf } from "../types/helpers";
+
+export type AggregationPropertyTypeResult<
+	PropertyName extends string,
+	Aggregation,
+	Got,
+	Expected,
+	Result,
+	Check = Got,
+> =
+	IsSomeSortOf<Check, Expected> extends true
+		? Result
+		: InvalidPropertyTypeInAggregation<
+				PropertyName,
+				Aggregation,
+				Got,
+				Expected
+			>;
+
+type ExtractAggregationField<Aggregation> = {
+	[K in keyof Aggregation]: Aggregation[K] extends {
+		field?: infer Field extends string;
+	}
+		? Field
+		: never;
+}[keyof Aggregation];
+
+export type AggregationFieldResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Aggregation,
+	Result,
+	Field extends string = ExtractAggregationField<Aggregation>,
+> =
+	CanBeUsedInAggregation<Field, Index, E> extends true
+		? Result
+		: InvalidFieldInAggregation<Field, Index, Aggregation>;
+
+type AggregationFieldTypeCheckResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Aggregation,
+	Field extends string,
+	Expected,
+	Result,
+> =
+	IsSomeSortOf<TypeOfField<Field, E, Index>, Expected> extends true
+		? Result
+		: InvalidFieldTypeInAggregation<
+				Field,
+				Index,
+				Aggregation,
+				TypeOfField<Field, E, Index>,
+				Expected
+			>;
+
+export type AggregationFieldTypeResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Aggregation,
+	Expected,
+	Result,
+	Field extends string = ExtractAggregationField<Aggregation>,
+> = AggregationFieldResult<
+	E,
+	Index,
+	Aggregation,
+	AggregationFieldTypeCheckResult<
+		E,
+		Index,
+		Aggregation,
+		Field,
+		Expected,
+		Result
+	>,
+	Field
+>;
+
+export type AggregationTwoFieldTypeResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Aggregation,
+	FirstField extends string,
+	FirstExpected,
+	SecondField extends string,
+	SecondExpected,
+	Result,
+> = AggregationFieldResult<
+	E,
+	Index,
+	Aggregation,
+	AggregationFieldResult<
+		E,
+		Index,
+		Aggregation,
+		AggregationFieldTypeCheckResult<
+			E,
+			Index,
+			Aggregation,
+			FirstField,
+			FirstExpected,
+			AggregationFieldTypeCheckResult<
+				E,
+				Index,
+				Aggregation,
+				SecondField,
+				SecondExpected,
+				Result
+			>
+		>,
+		SecondField
+	>,
+	FirstField
+>;

--- a/src/aggregations/metrics/boxplot.ts
+++ b/src/aggregations/metrics/boxplot.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation

--- a/src/aggregations/metrics/boxplot.ts
+++ b/src/aggregations/metrics/boxplot.ts
@@ -1,11 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation
@@ -19,23 +12,20 @@ export type Boxplot<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
-			? {
-					min: number;
-					max: number;
-					q1: number;
-					q2: number;
-					q3: number;
-					lower: number;
-					upper: number;
-				}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					number
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			{
+				min: number;
+				max: number;
+				q1: number;
+				q2: number;
+				q3: number;
+				lower: number;
+				upper: number;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/cartesian_bounds.ts
+++ b/src/aggregations/metrics/cartesian_bounds.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-bounds-aggregation

--- a/src/aggregations/metrics/cartesian_bounds.ts
+++ b/src/aggregations/metrics/cartesian_bounds.ts
@@ -1,8 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-} from "../..";
+import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-bounds-aggregation
@@ -16,8 +12,11 @@ export type CartesianBounds<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				bounds: {
 					top_left: {
 						x: number;
@@ -28,6 +27,7 @@ export type CartesianBounds<
 						y: number;
 					};
 				};
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/cartesian_centroid.ts
+++ b/src/aggregations/metrics/cartesian_centroid.ts
@@ -1,12 +1,5 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
 import type { EsPoint, EsShape } from "../../types/fields";
-import type { IsSomeSortOf, Not } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-centroid-aggregation
@@ -20,23 +13,18 @@ export type CartesianCentroid<
 		field: infer Field extends string;
 	};
 }
-	? Not<CanBeUsedInAggregation<Field, Index, E>> extends true
-		? InvalidFieldInAggregation<Field, Index, Agg>
-		: Not<
-					IsSomeSortOf<TypeOfField<Field, E, Index>, EsPoint | EsShape>
-				> extends true
-			? InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					EsPoint | EsShape
-				>
-			: {
-					location: {
-						x: number;
-						y: number;
-					};
-					count: number;
-				}
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			EsPoint | EsShape,
+			{
+				location: {
+					x: number;
+					y: number;
+				};
+				count: number;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/cartesian_centroid.ts
+++ b/src/aggregations/metrics/cartesian_centroid.ts
@@ -1,5 +1,6 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
 import type { EsPoint, EsShape } from "../../types/fields";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-centroid-aggregation

--- a/src/aggregations/metrics/extended_stats.ts
+++ b/src/aggregations/metrics/extended_stats.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-extendedstats-aggregation

--- a/src/aggregations/metrics/extended_stats.ts
+++ b/src/aggregations/metrics/extended_stats.ts
@@ -1,8 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-} from "../..";
+import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-extendedstats-aggregation
@@ -16,8 +12,11 @@ export type ExtendedStats<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				count: number;
 				min: number;
 				min_as_string?: string;
@@ -55,6 +54,7 @@ export type ExtendedStats<
 					lower_sampling: number;
 					lower_sampling_as_string?: string;
 				};
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/function.ts
+++ b/src/aggregations/metrics/function.ts
@@ -1,8 +1,5 @@
-import type {
-	AggregationFieldResult,
-	ElasticsearchIndexes,
-	TypeOfField,
-} from "../..";
+import type { ElasticsearchIndexes, TypeOfField } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 type ExtractAggField<Agg> = {
 	[Fn in Extract<keyof Agg, AggFunction>]: Agg[Fn] extends {

--- a/src/aggregations/metrics/function.ts
+++ b/src/aggregations/metrics/function.ts
@@ -1,7 +1,6 @@
 import type {
-	CanBeUsedInAggregation,
+	AggregationFieldResult,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
 	TypeOfField,
 } from "../..";
 
@@ -22,9 +21,12 @@ export type Function<
 	Index extends string,
 	Agg,
 	FieldAgg = ExtractAggField<Agg>,
-> = FieldAgg extends { fn: string; field: infer Field extends string }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+> = FieldAgg extends { fn: string; field: string }
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				value_as_string?: string;
 				value: FieldAgg["fn"] extends AggFunctionsNumber
 					? number
@@ -32,5 +34,5 @@ export type Function<
 						? number
 						: number | string;
 			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+		>
 	: never;

--- a/src/aggregations/metrics/geo_bounds.ts
+++ b/src/aggregations/metrics/geo_bounds.ts
@@ -1,8 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-} from "../..";
+import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geobounds-aggregation
@@ -17,8 +13,11 @@ export type GeoBounds<
 		wrap_longitude?: boolean;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				bounds: {
 					top_left: {
 						lat: number;
@@ -29,6 +28,7 @@ export type GeoBounds<
 						lon: number;
 					};
 				};
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/geo_bounds.ts
+++ b/src/aggregations/metrics/geo_bounds.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geobounds-aggregation

--- a/src/aggregations/metrics/geo_centroid.ts
+++ b/src/aggregations/metrics/geo_centroid.ts
@@ -1,8 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-} from "../..";
+import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geocentroid-aggregation
@@ -16,13 +12,17 @@ export type GeoCentroid<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				location: {
 					lat: number;
 					lon: number;
 				};
 				count: number;
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/geo_centroid.ts
+++ b/src/aggregations/metrics/geo_centroid.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geocentroid-aggregation

--- a/src/aggregations/metrics/geo_line.ts
+++ b/src/aggregations/metrics/geo_line.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geo-line

--- a/src/aggregations/metrics/geo_line.ts
+++ b/src/aggregations/metrics/geo_line.ts
@@ -1,8 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-} from "../..";
+import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geo-line
@@ -18,15 +14,18 @@ export type GeoLine<
 		};
 		// Required only if not in a nested time_series aggregation. So optional for simplicity
 		// sort?: {
-		// 	field: string;
+		// 	field: infer Field extends string;
 		// };
 		// include_sort?: boolean;
 		// size?: number;
 		// sort_order?: OrLowercase<"ASC" | "DESC">;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				type: "Feature";
 				geometry: {
 					type: "LineString";
@@ -35,6 +34,7 @@ export type GeoLine<
 				properties: {
 					complete: boolean;
 				};
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/matrix_stats.ts
+++ b/src/aggregations/metrics/matrix_stats.ts
@@ -1,5 +1,6 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
 import type { IsStringLiteral } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-matrix-stats-aggregation

--- a/src/aggregations/metrics/matrix_stats.ts
+++ b/src/aggregations/metrics/matrix_stats.ts
@@ -1,11 +1,5 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf, IsStringLiteral, Not } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { IsStringLiteral } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-matrix-stats-aggregation
@@ -22,36 +16,29 @@ export type MatrixStats<
 	? {
 			doc_count: number;
 			fields: {
-				[index in keyof Field]: Not<
-					CanBeUsedInAggregation<Field[index], Index, E>
-				> extends true
-					? InvalidFieldInAggregation<Field[index], Index, Agg>
-					: Not<
-								IsSomeSortOf<TypeOfField<Field[index], E, Index>, number>
-							> extends true
-						? InvalidFieldTypeInAggregation<
-								Field[index],
-								Index,
-								Agg,
-								TypeOfField<Field[index], E, Index>,
-								number
-							>
-						: {
-								name: Field[index];
-								count: number;
-								mean: number;
-								variance: number;
-								skewness: number;
-								kurtosis: number;
-								covariance: Record<Field[number], number>;
-								correlation: {
-									[K in Field[number]]: K extends Field[index]
-										? IsStringLiteral<K> extends true
-											? 1
-											: number
-										: number;
-								};
-							};
+				[index in keyof Field]: AggregationFieldTypeResult<
+					E,
+					Index,
+					Agg,
+					number,
+					{
+						name: Field[index];
+						count: number;
+						mean: number;
+						variance: number;
+						skewness: number;
+						kurtosis: number;
+						covariance: Record<Field[number], number>;
+						correlation: {
+							[K in Field[number]]: K extends Field[index]
+								? IsStringLiteral<K> extends true
+									? 1
+									: number
+								: number;
+						};
+					},
+					Field[index]
+				>;
 			};
 		}
 	: never;

--- a/src/aggregations/metrics/median_absolute_deviation.ts
+++ b/src/aggregations/metrics/median_absolute_deviation.ts
@@ -1,11 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-median-absolute-deviation-aggregation
@@ -19,18 +12,15 @@ export type MedianAbsoluteDeviation<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
-			? {
-					value: number;
-					value_as_string?: string;
-				}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					number
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			{
+				value: number;
+				value_as_string?: string;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/median_absolute_deviation.ts
+++ b/src/aggregations/metrics/median_absolute_deviation.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-median-absolute-deviation-aggregation

--- a/src/aggregations/metrics/percentile_ranks.ts
+++ b/src/aggregations/metrics/percentile_ranks.ts
@@ -1,11 +1,5 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf, ToDecimal } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ToDecimal } from "../../types/helpers";
 
 type PercentilesValues<Percents extends readonly number[]> = {
 	[index in keyof Percents]: {
@@ -35,21 +29,18 @@ export type PercentileRanks<
 		keyed?: infer Keyed;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
-			? Keyed extends false
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			Keyed extends false
 				? {
 						values: PercentilesValues<Values>;
 					}
 				: {
 						values: PercentilesValuesToObject<PercentilesValues<Values>>;
-					}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					number
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+					},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/percentile_ranks.ts
+++ b/src/aggregations/metrics/percentile_ranks.ts
@@ -1,5 +1,6 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
 import type { ToDecimal } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 type PercentilesValues<Percents extends readonly number[]> = {
 	[index in keyof Percents]: {

--- a/src/aggregations/metrics/percentiles.ts
+++ b/src/aggregations/metrics/percentiles.ts
@@ -1,11 +1,5 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf, ToDecimal } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ToDecimal } from "../../types/helpers";
 
 type DefaultPercents = [1, 5, 25, 50, 75, 95, 99];
 
@@ -37,9 +31,12 @@ export type Percentiles<
 		keyed?: infer Keyed;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, number> extends true
-			? Keyed extends false
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			Keyed extends false
 				? {
 						values: PercentilesValues<
 							Percents extends number[] ? Percents : DefaultPercents
@@ -51,13 +48,7 @@ export type Percentiles<
 								Percents extends number[] ? Percents : DefaultPercents
 							>
 						>;
-					}
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					number
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+					},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/percentiles.ts
+++ b/src/aggregations/metrics/percentiles.ts
@@ -1,5 +1,6 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
 import type { ToDecimal } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 type DefaultPercents = [1, 5, 25, 50, 75, 95, 99];
 

--- a/src/aggregations/metrics/rate.ts
+++ b/src/aggregations/metrics/rate.ts
@@ -1,11 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf, Not } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-rate-aggregation
@@ -20,18 +13,15 @@ export type Rate<
 		field?: infer Field extends string;
 	};
 }
-	? Not<CanBeUsedInAggregation<Field, Index, E>> extends true
-		? InvalidFieldInAggregation<Field, Index, Agg>
-		: Not<IsSomeSortOf<TypeOfField<Field, E, Index>, number>> extends true
-			? InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					number
-				>
-			: {
-					value: number;
-					value_as_string?: string;
-				}
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			{
+				value: number;
+				value_as_string?: string;
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/rate.ts
+++ b/src/aggregations/metrics/rate.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-rate-aggregation

--- a/src/aggregations/metrics/stats.ts
+++ b/src/aggregations/metrics/stats.ts
@@ -1,8 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-} from "../..";
+import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-stats-aggregation
@@ -16,8 +12,11 @@ export type Stats<
 		field: infer Field extends string;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? {
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
 				count: number;
 				min: number;
 				min_as_string?: string;
@@ -27,6 +26,7 @@ export type Stats<
 				avg_as_string?: string;
 				sum: number;
 				sum_as_string?: string;
-			}
-		: InvalidFieldInAggregation<Field, Index, Agg>
+			},
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/stats.ts
+++ b/src/aggregations/metrics/stats.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationFieldResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-stats-aggregation

--- a/src/aggregations/metrics/string_stats.ts
+++ b/src/aggregations/metrics/string_stats.ts
@@ -1,11 +1,5 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf, Prettify } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { Prettify } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-string-stats-aggregation
@@ -20,27 +14,24 @@ export type StringStats<
 		show_distribution?: infer ShowDistribution;
 	};
 }
-	? CanBeUsedInAggregation<Field, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<Field, E, Index>, string> extends true
-			? Prettify<
-					{
-						count: number;
-						min_length: number;
-						max_length: number;
-						avg_length: number;
-						entropy: number;
-					} & {
-						[K in "distribution" as ShowDistribution extends true
-							? K
-							: never]: Record<string, number>;
-					}
-				>
-			: InvalidFieldTypeInAggregation<
-					Field,
-					Index,
-					Agg,
-					TypeOfField<Field, E, Index>,
-					string
-				>
-		: InvalidFieldInAggregation<Field, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			string,
+			Prettify<
+				{
+					count: number;
+					min_length: number;
+					max_length: number;
+					avg_length: number;
+					entropy: number;
+				} & {
+					[K in "distribution" as ShowDistribution extends true
+						? K
+						: never]: Record<string, number>;
+				}
+			>,
+			Field
+		>
 	: never;

--- a/src/aggregations/metrics/string_stats.ts
+++ b/src/aggregations/metrics/string_stats.ts
@@ -1,5 +1,6 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-string-stats-aggregation

--- a/src/aggregations/metrics/t_test.ts
+++ b/src/aggregations/metrics/t_test.ts
@@ -1,4 +1,5 @@
-import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationTwoFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-ttest-aggregation
@@ -13,22 +14,17 @@ export type TTest<
 		b?: { field?: infer FieldB extends string; script?: unknown };
 	};
 }
-	? AggregationFieldTypeResult<
+	? AggregationTwoFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			FieldA,
 			number,
-			AggregationFieldTypeResult<
-				E,
-				Index,
-				Agg,
-				number,
-				{
-					value: number;
-					value_as_string?: string;
-				},
-				FieldB
-			>,
-			FieldA
+			FieldB,
+			number,
+			{
+				value: number;
+				value_as_string?: string;
+			}
 		>
 	: never;

--- a/src/aggregations/metrics/t_test.ts
+++ b/src/aggregations/metrics/t_test.ts
@@ -1,11 +1,4 @@
-import type {
-	CanBeUsedInAggregation,
-	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
-} from "../..";
-import type { IsSomeSortOf } from "../../types/helpers";
+import type { AggregationFieldTypeResult, ElasticsearchIndexes } from "../..";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-ttest-aggregation
@@ -20,28 +13,22 @@ export type TTest<
 		b?: { field?: infer FieldB extends string; script?: unknown };
 	};
 }
-	? CanBeUsedInAggregation<FieldA, Index, E> extends true
-		? IsSomeSortOf<TypeOfField<FieldA, E, Index>, number> extends true
-			? CanBeUsedInAggregation<FieldB, Index, E> extends true
-				? IsSomeSortOf<TypeOfField<FieldB, E, Index>, number> extends true
-					? {
-							value: number;
-							value_as_string?: string;
-						}
-					: InvalidFieldTypeInAggregation<
-							FieldB,
-							Index,
-							Agg,
-							TypeOfField<FieldB, E, Index>,
-							number
-						>
-				: InvalidFieldInAggregation<FieldB, Index, Agg>
-			: InvalidFieldTypeInAggregation<
-					FieldA,
-					Index,
-					Agg,
-					TypeOfField<FieldA, E, Index>,
-					number
-				>
-		: InvalidFieldInAggregation<FieldA, Index, Agg>
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			AggregationFieldTypeResult<
+				E,
+				Index,
+				Agg,
+				number,
+				{
+					value: number;
+					value_as_string?: string;
+				},
+				FieldB
+			>,
+			FieldA
+		>
 	: never;

--- a/src/aggregations/metrics/weighted_avg.ts
+++ b/src/aggregations/metrics/weighted_avg.ts
@@ -1,11 +1,8 @@
 import type {
-	CanBeUsedInAggregation,
+	AggregationFieldResult,
+	AggregationFieldTypeResult,
 	ElasticsearchIndexes,
-	InvalidFieldInAggregation,
-	InvalidFieldTypeInAggregation,
-	TypeOfField,
 } from "../..";
-import type { IsSomeSortOf, Not } from "../../types/helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-weight-avg-aggregation
@@ -26,35 +23,34 @@ export type WeightedAvg<
 		};
 	};
 }
-	? Not<CanBeUsedInAggregation<ValueField, Index, E>> extends true
-		? InvalidFieldInAggregation<ValueField, Index, Agg>
-		: Not<CanBeUsedInAggregation<WeightField, Index, E>> extends true
-			? InvalidFieldInAggregation<WeightField, Index, Agg>
-			: Not<
-						IsSomeSortOf<TypeOfField<WeightField, E, Index>, number>
-					> extends true
-				? InvalidFieldTypeInAggregation<
-						WeightField,
+	? AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			AggregationFieldResult<
+				E,
+				Index,
+				Agg,
+				AggregationFieldTypeResult<
+					E,
+					Index,
+					Agg,
+					number,
+					AggregationFieldTypeResult<
+						E,
 						Index,
 						Agg,
-						TypeOfField<WeightField, E, Index>,
-						number
-					>
-				: Not<
-							IsSomeSortOf<
-								TypeOfField<ValueField, E, Index>,
-								number | Array<number>
-							>
-						> extends true
-					? InvalidFieldTypeInAggregation<
-							ValueField,
-							Index,
-							Agg,
-							TypeOfField<ValueField, E, Index>,
-							number | Array<number>
-						>
-					: {
+						number | Array<number>,
+						{
 							value: number;
 							value_as_string?: string;
-						}
+						},
+						ValueField
+					>,
+					WeightField
+				>,
+				WeightField
+			>,
+			ValueField
+		>
 	: never;

--- a/src/aggregations/metrics/weighted_avg.ts
+++ b/src/aggregations/metrics/weighted_avg.ts
@@ -1,8 +1,5 @@
-import type {
-	AggregationFieldResult,
-	AggregationFieldTypeResult,
-	ElasticsearchIndexes,
-} from "../..";
+import type { ElasticsearchIndexes } from "../..";
+import type { AggregationTwoFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-weight-avg-aggregation
@@ -23,34 +20,17 @@ export type WeightedAvg<
 		};
 	};
 }
-	? AggregationFieldResult<
+	? AggregationTwoFieldTypeResult<
 			E,
 			Index,
 			Agg,
-			AggregationFieldResult<
-				E,
-				Index,
-				Agg,
-				AggregationFieldTypeResult<
-					E,
-					Index,
-					Agg,
-					number,
-					AggregationFieldTypeResult<
-						E,
-						Index,
-						Agg,
-						number | Array<number>,
-						{
-							value: number;
-							value_as_string?: string;
-						},
-						ValueField
-					>,
-					WeightField
-				>,
-				WeightField
-			>,
-			ValueField
+			ValueField,
+			number | Array<number>,
+			WeightField,
+			number,
+			{
+				value: number;
+				value_as_string?: string;
+			}
 		>
 	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,7 +8,6 @@ import type {
 	DeepPickPaths,
 	IsNever,
 	IsOptional,
-	IsSomeSortOf,
 	IsStringLiteral,
 	Optional,
 	RArray,
@@ -187,65 +186,6 @@ export type InvalidPropertyTypeInAggregation<
 	expected: expected;
 	hint: "Check the aggregation configuration syntax in Elasticsearch documentation";
 };
-
-export type AggregationPropertyTypeResult<
-	PropertyName extends string,
-	Aggregation,
-	Got,
-	Expected,
-	Result,
-	Check = Got,
-> =
-	IsSomeSortOf<Check, Expected> extends true
-		? Result
-		: InvalidPropertyTypeInAggregation<
-				PropertyName,
-				Aggregation,
-				Got,
-				Expected
-			>;
-
-type ExtractAggregationField<Aggregation> = {
-	[K in keyof Aggregation]: Aggregation[K] extends {
-		field?: infer Field extends string;
-	}
-		? Field
-		: never;
-}[keyof Aggregation];
-
-export type AggregationFieldResult<
-	E extends ElasticsearchIndexes,
-	Index extends string,
-	Aggregation,
-	Result,
-	Field extends string = ExtractAggregationField<Aggregation>,
-> =
-	CanBeUsedInAggregation<Field, Index, E> extends true
-		? Result
-		: InvalidFieldInAggregation<Field, Index, Aggregation>;
-
-export type AggregationFieldTypeResult<
-	E extends ElasticsearchIndexes,
-	Index extends string,
-	Aggregation,
-	Expected,
-	Result,
-	Field extends string = ExtractAggregationField<Aggregation>,
-> = AggregationFieldResult<
-	E,
-	Index,
-	Aggregation,
-	IsSomeSortOf<TypeOfField<Field, E, Index>, Expected> extends true
-		? Result
-		: InvalidFieldTypeInAggregation<
-				Field,
-				Index,
-				Aggregation,
-				TypeOfField<Field, E, Index>,
-				Expected
-			>,
-	Field
->;
 
 export type PossibleFieldsWithWildcards<
 	Index,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,6 +8,7 @@ import type {
 	DeepPickPaths,
 	IsNever,
 	IsOptional,
+	IsSomeSortOf,
 	IsStringLiteral,
 	Optional,
 	RArray,
@@ -186,6 +187,65 @@ export type InvalidPropertyTypeInAggregation<
 	expected: expected;
 	hint: "Check the aggregation configuration syntax in Elasticsearch documentation";
 };
+
+export type AggregationPropertyTypeResult<
+	PropertyName extends string,
+	Aggregation,
+	Got,
+	Expected,
+	Result,
+	Check = Got,
+> =
+	IsSomeSortOf<Check, Expected> extends true
+		? Result
+		: InvalidPropertyTypeInAggregation<
+				PropertyName,
+				Aggregation,
+				Got,
+				Expected
+			>;
+
+type ExtractAggregationField<Aggregation> = {
+	[K in keyof Aggregation]: Aggregation[K] extends {
+		field?: infer Field extends string;
+	}
+		? Field
+		: never;
+}[keyof Aggregation];
+
+export type AggregationFieldResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Aggregation,
+	Result,
+	Field extends string = ExtractAggregationField<Aggregation>,
+> =
+	CanBeUsedInAggregation<Field, Index, E> extends true
+		? Result
+		: InvalidFieldInAggregation<Field, Index, Aggregation>;
+
+export type AggregationFieldTypeResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Aggregation,
+	Expected,
+	Result,
+	Field extends string = ExtractAggregationField<Aggregation>,
+> = AggregationFieldResult<
+	E,
+	Index,
+	Aggregation,
+	IsSomeSortOf<TypeOfField<Field, E, Index>, Expected> extends true
+		? Result
+		: InvalidFieldTypeInAggregation<
+				Field,
+				Index,
+				Aggregation,
+				TypeOfField<Field, E, Index>,
+				Expected
+			>,
+	Field
+>;
 
 export type PossibleFieldsWithWildcards<
 	Index,


### PR DESCRIPTION
## Summary
- add shared helper types for aggregation field/property validation
- replace repeated `CanBeUsedInAggregation` / field type validation branches across aggregations
- add a patch changeset

## Notes
- `tsc --extendedDiagnostics` shows fewer instantiations and slightly lower check time after the refactor.

Closes #294