### PR TITLE
fix: support script-only metric aggregations

### DIFF
--- a/.changeset/script-aggregation-fields.md
+++ b/.changeset/script-aggregation-fields.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Support script-only metric aggregations that omit `field`.

--- a/src/aggregations/helpers.ts
+++ b/src/aggregations/helpers.ts
@@ -6,7 +6,7 @@ import type {
 	InvalidPropertyTypeInAggregation,
 	TypeOfField,
 } from "../lib";
-import type { IsSomeSortOf } from "../types/helpers";
+import type { IsNever, IsSomeSortOf } from "../types/helpers";
 
 export type AggregationPropertyTypeResult<
 	PropertyName extends string,
@@ -33,6 +33,14 @@ type ExtractAggregationField<Aggregation> = {
 		: never;
 }[keyof Aggregation];
 
+export type ExtractFieldFromFieldOrScript<Config> = Config extends {
+	field: infer Field extends string;
+}
+	? Field
+	: Config extends { script: unknown }
+		? never
+		: never;
+
 export type AggregationFieldResult<
 	E extends ElasticsearchIndexes,
 	Index extends string,
@@ -40,9 +48,11 @@ export type AggregationFieldResult<
 	Result,
 	Field extends string = ExtractAggregationField<Aggregation>,
 > =
-	CanBeUsedInAggregation<Field, Index, E> extends true
+	IsNever<Field> extends true
 		? Result
-		: InvalidFieldInAggregation<Field, Index, Aggregation>;
+		: CanBeUsedInAggregation<Field, Index, E> extends true
+			? Result
+			: InvalidFieldInAggregation<Field, Index, Aggregation>;
 
 type AggregationFieldTypeCheckResult<
 	E extends ElasticsearchIndexes,
@@ -69,20 +79,48 @@ export type AggregationFieldTypeResult<
 	Expected,
 	Result,
 	Field extends string = ExtractAggregationField<Aggregation>,
-> = AggregationFieldResult<
-	E,
-	Index,
+> =
+	IsNever<Field> extends true
+		? Result
+		: AggregationFieldResult<
+				E,
+				Index,
+				Aggregation,
+				AggregationFieldTypeCheckResult<
+					E,
+					Index,
+					Aggregation,
+					Field,
+					Expected,
+					Result
+				>,
+				Field
+			>;
+
+type AggregationMaybeFieldTypeResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
 	Aggregation,
-	AggregationFieldTypeCheckResult<
-		E,
-		Index,
-		Aggregation,
-		Field,
-		Expected,
-		Result
-	>,
-	Field
->;
+	Field extends string,
+	Expected,
+	Result,
+> =
+	IsNever<Field> extends true
+		? Result
+		: AggregationFieldResult<
+				E,
+				Index,
+				Aggregation,
+				AggregationFieldTypeCheckResult<
+					E,
+					Index,
+					Aggregation,
+					Field,
+					Expected,
+					Result
+				>,
+				Field
+			>;
 
 export type AggregationTwoFieldTypeResult<
 	E extends ElasticsearchIndexes,
@@ -93,30 +131,18 @@ export type AggregationTwoFieldTypeResult<
 	SecondField extends string,
 	SecondExpected,
 	Result,
-> = AggregationFieldResult<
+> = AggregationMaybeFieldTypeResult<
 	E,
 	Index,
 	Aggregation,
-	AggregationFieldResult<
+	FirstField,
+	FirstExpected,
+	AggregationMaybeFieldTypeResult<
 		E,
 		Index,
 		Aggregation,
-		AggregationFieldTypeCheckResult<
-			E,
-			Index,
-			Aggregation,
-			FirstField,
-			FirstExpected,
-			AggregationFieldTypeCheckResult<
-				E,
-				Index,
-				Aggregation,
-				SecondField,
-				SecondExpected,
-				Result
-			>
-		>,
-		SecondField
-	>,
-	FirstField
+		SecondField,
+		SecondExpected,
+		Result
+	>
 >;

--- a/src/aggregations/metrics/boxplot.ts
+++ b/src/aggregations/metrics/boxplot.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type {
+	AggregationFieldTypeResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-boxplot-aggregation
@@ -9,9 +12,7 @@ export type Boxplot<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	boxplot: {
-		field: infer Field extends string;
-	};
+	boxplot: infer Boxplot extends { field: string } | { script: unknown };
 }
 	? AggregationFieldTypeResult<
 			E,
@@ -27,6 +28,6 @@ export type Boxplot<
 				lower: number;
 				upper: number;
 			},
-			Field
+			ExtractFieldFromFieldOrScript<Boxplot>
 		>
 	: never;

--- a/src/aggregations/metrics/cartesian_bounds.ts
+++ b/src/aggregations/metrics/cartesian_bounds.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type {
+	AggregationFieldResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-bounds-aggregation
@@ -9,9 +12,9 @@ export type CartesianBounds<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	cartesian_bounds: {
-		field: infer Field extends string;
-	};
+	cartesian_bounds: infer CartesianBounds extends
+		| { field: string }
+		| { script: unknown };
 }
 	? AggregationFieldResult<
 			E,
@@ -29,6 +32,6 @@ export type CartesianBounds<
 					};
 				};
 			},
-			Field
+			ExtractFieldFromFieldOrScript<CartesianBounds>
 		>
 	: never;

--- a/src/aggregations/metrics/cartesian_centroid.ts
+++ b/src/aggregations/metrics/cartesian_centroid.ts
@@ -1,6 +1,9 @@
 import type { ElasticsearchIndexes } from "../..";
 import type { EsPoint, EsShape } from "../../types/fields";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type {
+	AggregationFieldTypeResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-cartesian-centroid-aggregation
@@ -10,9 +13,9 @@ export type CartesianCentroid<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	cartesian_centroid: {
-		field: infer Field extends string;
-	};
+	cartesian_centroid: infer CartesianCentroid extends
+		| { field: string }
+		| { script: unknown };
 }
 	? AggregationFieldTypeResult<
 			E,
@@ -26,6 +29,6 @@ export type CartesianCentroid<
 				};
 				count: number;
 			},
-			Field
+			ExtractFieldFromFieldOrScript<CartesianCentroid>
 		>
 	: never;

--- a/src/aggregations/metrics/extended_stats.ts
+++ b/src/aggregations/metrics/extended_stats.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type {
+	AggregationFieldResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-extendedstats-aggregation
@@ -9,9 +12,9 @@ export type ExtendedStats<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	extended_stats: {
-		field: infer Field extends string;
-	};
+	extended_stats: infer ExtendedStats extends
+		| { field: string }
+		| { script: unknown };
 }
 	? AggregationFieldResult<
 			E,
@@ -56,6 +59,6 @@ export type ExtendedStats<
 					lower_sampling_as_string?: string;
 				};
 			},
-			Field
+			ExtractFieldFromFieldOrScript<ExtendedStats>
 		>
 	: never;

--- a/src/aggregations/metrics/function.ts
+++ b/src/aggregations/metrics/function.ts
@@ -1,4 +1,5 @@
 import type { ElasticsearchIndexes, TypeOfField } from "../..";
+import type { IsNever } from "../../types/helpers";
 import type { AggregationFieldResult } from "../helpers";
 
 type ExtractAggField<Agg> = {
@@ -6,10 +7,30 @@ type ExtractAggField<Agg> = {
 		field: infer F;
 	}
 		? { fn: Fn; field: F }
-		: never;
+		: Agg[Fn] extends { script: unknown }
+			? { fn: Fn; script: unknown }
+			: never;
 }[Extract<keyof Agg, AggFunction>];
 
 type AggFunctionsNumber = "value_count" | "cardinality";
+
+type FunctionResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Fn,
+	Field = never,
+> = {
+	value_as_string?: string;
+	value: Fn extends AggFunctionsNumber
+		? number
+		: IsNever<Field> extends true
+			? number
+			: Field extends string
+				? TypeOfField<Field, E, Index> extends number
+					? number
+					: number | string
+				: number;
+};
 
 export type AggFunction = AggFunctionsNumber | "sum" | "avg" | "max" | "min";
 
@@ -23,13 +44,8 @@ export type Function<
 			E,
 			Index,
 			Agg,
-			{
-				value_as_string?: string;
-				value: FieldAgg["fn"] extends AggFunctionsNumber
-					? number
-					: TypeOfField<FieldAgg["field"], E, Index> extends number
-						? number
-						: number | string;
-			}
+			FunctionResult<E, Index, FieldAgg["fn"], FieldAgg["field"]>
 		>
-	: never;
+	: FieldAgg extends { fn: string; script: unknown }
+		? FunctionResult<E, Index, FieldAgg["fn"]>
+		: never;

--- a/src/aggregations/metrics/geo_bounds.ts
+++ b/src/aggregations/metrics/geo_bounds.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type {
+	AggregationFieldResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geobounds-aggregation
@@ -9,10 +12,9 @@ export type GeoBounds<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	geo_bounds: {
-		field: infer Field extends string;
-		wrap_longitude?: boolean;
-	};
+	geo_bounds: infer GeoBounds extends
+		| { field: string; wrap_longitude?: boolean }
+		| { script: unknown; wrap_longitude?: boolean };
 }
 	? AggregationFieldResult<
 			E,
@@ -30,6 +32,6 @@ export type GeoBounds<
 					};
 				};
 			},
-			Field
+			ExtractFieldFromFieldOrScript<GeoBounds>
 		>
 	: never;

--- a/src/aggregations/metrics/geo_centroid.ts
+++ b/src/aggregations/metrics/geo_centroid.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type {
+	AggregationFieldResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-geocentroid-aggregation
@@ -9,9 +12,9 @@ export type GeoCentroid<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	geo_centroid: {
-		field: infer Field extends string;
-	};
+	geo_centroid: infer GeoCentroid extends
+		| { field: string }
+		| { script: unknown };
 }
 	? AggregationFieldResult<
 			E,
@@ -24,6 +27,6 @@ export type GeoCentroid<
 				};
 				count: number;
 			},
-			Field
+			ExtractFieldFromFieldOrScript<GeoCentroid>
 		>
 	: never;

--- a/src/aggregations/metrics/median_absolute_deviation.ts
+++ b/src/aggregations/metrics/median_absolute_deviation.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type {
+	AggregationFieldTypeResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-median-absolute-deviation-aggregation
@@ -9,9 +12,9 @@ export type MedianAbsoluteDeviation<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	median_absolute_deviation: {
-		field: infer Field extends string;
-	};
+	median_absolute_deviation: infer MedianAbsoluteDeviation extends
+		| { field: string }
+		| { script: unknown };
 }
 	? AggregationFieldTypeResult<
 			E,
@@ -22,6 +25,6 @@ export type MedianAbsoluteDeviation<
 				value: number;
 				value_as_string?: string;
 			},
-			Field
+			ExtractFieldFromFieldOrScript<MedianAbsoluteDeviation>
 		>
 	: never;

--- a/src/aggregations/metrics/percentile_ranks.ts
+++ b/src/aggregations/metrics/percentile_ranks.ts
@@ -1,6 +1,9 @@
 import type { ElasticsearchIndexes } from "../..";
 import type { ToDecimal } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type {
+	AggregationFieldTypeResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 type PercentilesValues<Percents extends readonly number[]> = {
 	[index in keyof Percents]: {
@@ -24,24 +27,24 @@ export type PercentileRanks<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	percentile_ranks: {
-		field: infer Field extends string;
-		values: infer Values extends number[];
-		keyed?: infer Keyed;
-	};
+	percentile_ranks: infer PercentileRanks extends
+		| { field: string; values: number[]; keyed?: unknown }
+		| { script: unknown; values: number[]; keyed?: unknown };
 }
 	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
 			number,
-			Keyed extends false
+			PercentileRanks extends { keyed: false }
 				? {
-						values: PercentilesValues<Values>;
+						values: PercentilesValues<PercentileRanks["values"]>;
 					}
 				: {
-						values: PercentilesValuesToObject<PercentilesValues<Values>>;
+						values: PercentilesValuesToObject<
+							PercentilesValues<PercentileRanks["values"]>
+						>;
 					},
-			Field
+			ExtractFieldFromFieldOrScript<PercentileRanks>
 		>
 	: never;

--- a/src/aggregations/metrics/percentiles.ts
+++ b/src/aggregations/metrics/percentiles.ts
@@ -1,6 +1,9 @@
 import type { ElasticsearchIndexes } from "../..";
 import type { ToDecimal } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type {
+	AggregationFieldTypeResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 type DefaultPercents = [1, 5, 25, 50, 75, 95, 99];
 
@@ -26,30 +29,34 @@ export type Percentiles<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	percentiles: {
-		field: infer Field extends string;
-		percents?: infer Percents;
-		keyed?: infer Keyed;
-	};
+	percentiles: infer Percentiles extends
+		| { field: string; percents?: unknown; keyed?: unknown }
+		| { script: unknown; percents?: unknown; keyed?: unknown };
 }
 	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
 			number,
-			Keyed extends false
+			Percentiles extends { keyed: false }
 				? {
 						values: PercentilesValues<
-							Percents extends number[] ? Percents : DefaultPercents
+							Percentiles extends { percents: infer Percents extends number[] }
+								? Percents
+								: DefaultPercents
 						>;
 					}
 				: {
 						values: PercentilesValuesToObject<
 							PercentilesValues<
-								Percents extends number[] ? Percents : DefaultPercents
+								Percentiles extends {
+									percents: infer Percents extends number[];
+								}
+									? Percents
+									: DefaultPercents
 							>
 						>;
 					},
-			Field
+			ExtractFieldFromFieldOrScript<Percentiles>
 		>
 	: never;

--- a/src/aggregations/metrics/stats.ts
+++ b/src/aggregations/metrics/stats.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type {
+	AggregationFieldResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-stats-aggregation
@@ -9,9 +12,7 @@ export type Stats<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	stats: {
-		field: infer Field extends string;
-	};
+	stats: infer Stats extends { field: string } | { script: unknown };
 }
 	? AggregationFieldResult<
 			E,
@@ -28,6 +29,6 @@ export type Stats<
 				sum: number;
 				sum_as_string?: string;
 			},
-			Field
+			ExtractFieldFromFieldOrScript<Stats>
 		>
 	: never;

--- a/src/aggregations/metrics/string_stats.ts
+++ b/src/aggregations/metrics/string_stats.ts
@@ -1,6 +1,9 @@
 import type { ElasticsearchIndexes } from "../..";
 import type { Prettify } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type {
+	AggregationFieldTypeResult,
+	ExtractFieldFromFieldOrScript,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-string-stats-aggregation
@@ -10,10 +13,9 @@ export type StringStats<
 	Index extends string,
 	Agg,
 > = Agg extends {
-	string_stats: {
-		field: infer Field extends string;
-		show_distribution?: infer ShowDistribution;
-	};
+	string_stats: infer StringStats extends
+		| { field: string; show_distribution?: unknown }
+		| { script: unknown; show_distribution?: unknown };
 }
 	? AggregationFieldTypeResult<
 			E,
@@ -28,11 +30,13 @@ export type StringStats<
 					avg_length: number;
 					entropy: number;
 				} & {
-					[K in "distribution" as ShowDistribution extends true
+					[K in "distribution" as StringStats extends {
+						show_distribution: true;
+					}
 						? K
 						: never]: Record<string, number>;
 				}
 			>,
-			Field
+			ExtractFieldFromFieldOrScript<StringStats>
 		>
 	: never;

--- a/tests/aggregations/metrics/function.test.ts
+++ b/tests/aggregations/metrics/function.test.ts
@@ -27,6 +27,36 @@ describe("Leaf Function Aggregations", () => {
 		}>();
 	});
 
+	test("with script-only metric functions", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
+				sum_script: {
+					sum: {
+						script: {
+							source: "doc['total'].value * 2";
+						};
+					};
+				};
+				value_count_script: {
+					value_count: {
+						script: "doc['total'].value";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			sum_script: {
+				value: number;
+				value_as_string?: string;
+			};
+			value_count_script: {
+				value: number;
+				value_as_string?: string;
+			};
+		}>();
+	});
+
 	test("with generic function", () => {
 		const fn = "" as "min" | "max" | "sum" | "avg";
 		const query = typedEs(client, {

--- a/tests/aggregations/metrics/stats.test.ts
+++ b/tests/aggregations/metrics/stats.test.ts
@@ -29,6 +29,32 @@ describe("Stats Aggregation", () => {
 		}>();
 	});
 
+	test("with script instead of field", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
+				total_stats: {
+					stats: {
+						script: "doc['total'].value * 2";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			total_stats: {
+				count: number;
+				min: number;
+				min_as_string?: string;
+				max: number;
+				max_as_string?: string;
+				avg: number;
+				avg_as_string?: string;
+				sum: number;
+				sum_as_string?: string;
+			};
+		}>();
+	});
+
 	test("fails when using an invalid field", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",

--- a/tests/aggregations/metrics/weighted_avg.test.ts
+++ b/tests/aggregations/metrics/weighted_avg.test.ts
@@ -68,6 +68,30 @@ describe("WeightedAvg Aggregations", () => {
 		}>();
 	});
 
+	test("with value and weight scripts", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				weighted_score: {
+					weighted_avg: {
+						value: {
+							script: "doc.score.value + 1";
+						};
+						weight: {
+							script: "1";
+						};
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			weighted_score: {
+				value: number;
+				value_as_string?: string;
+			};
+		}>();
+	});
+
 	test("fails when using an invalid field type (weight)", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",


### PR DESCRIPTION
## Summary
- allow metric aggregations that support `script` to infer outputs when `field` is omitted
- add script-only regression coverage for function, stats, and weighted average aggregations
- add a patch changeset

## Notes
- Field validation is skipped only when the aggregation config provides `script` without a `field`; field-backed aggregations still validate field names and field types.

Closes #139