### PR TITLE
add support for _all index

### DIFF
--- a/.changeset/support-all-index.md
+++ b/.changeset/support-all-index.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add `_all` as a supported typed search index target.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -31,6 +31,11 @@ import type {
 } from "./types/wildcard-search";
 
 type WithVariants<T extends string> = `${T}.${string}` | T;
+type AllIndex = "_all";
+export type ElasticsearchIndex<Indexes extends ElasticsearchIndexes> =
+	| Extract<keyof Indexes, string>
+	| AllIndex;
+
 type FilterToOnlyLeaf<
 	T extends string,
 	E extends ElasticsearchIndexes,
@@ -69,17 +74,26 @@ export type PossibleFields<
 	Indexes extends ElasticsearchIndexes,
 	OnlyLeaf = false,
 	AllowVariants = false,
-> = Index extends keyof Indexes
-	? AllowVariants extends true
-		?
-				| FilterToOnlyLeaf<
-						WithVariants<JoinKeys<Indexes[Index], OnlyLeaf>>,
-						Indexes,
-						Index
-				  >
-				| JoinKeys<Indexes[Index], OnlyLeaf>
-		: JoinKeys<Indexes[Index], OnlyLeaf>
-	: never;
+> = Index extends AllIndex
+	? {
+			[K in Extract<keyof Indexes, string>]: PossibleFields<
+				K,
+				Indexes,
+				OnlyLeaf,
+				AllowVariants
+			>;
+		}[Extract<keyof Indexes, string>]
+	: Index extends keyof Indexes
+		? AllowVariants extends true
+			?
+					| FilterToOnlyLeaf<
+							WithVariants<JoinKeys<Indexes[Index], OnlyLeaf>>,
+							Indexes,
+							Extract<Index, string>
+					  >
+					| JoinKeys<Indexes[Index], OnlyLeaf>
+			: JoinKeys<Indexes[Index], OnlyLeaf>
+		: never;
 
 export type CanBeUsedInAggregation<
 	Field extends string,
@@ -196,8 +210,17 @@ export type PossibleFieldsWithWildcards<
 export type TypeOfField<
 	Field extends string,
 	Indexes extends ElasticsearchIndexes,
-	Index extends keyof Indexes,
-> = RecursiveDotNotation<Indexes[Index], Field>;
+	Index extends string,
+> = Index extends AllIndex
+	? {
+			[K in Extract<keyof Indexes, string>]: RecursiveDotNotation<
+				Indexes[K],
+				Field
+			>;
+		}[Extract<keyof Indexes, string>]
+	: Index extends keyof Indexes
+		? RecursiveDotNotation<Indexes[Index], Field>
+		: never;
 
 export type RequestedIndex<Query> = "index" extends keyof Query
 	? Query["index"] extends string
@@ -441,6 +464,16 @@ type IsParentKeyALeaf<
 			: false
 	: false;
 
+type DeepPickFieldsForIndex<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Paths extends string,
+> = Index extends AllIndex
+	? E[Extract<keyof E, string>]
+	: Index extends keyof E
+		? DeepPickPaths<E[Index], Paths>
+		: never;
+
 export type ElasticsearchOutputFields<
 	QueryWithSource extends Partial<SearchRequest>,
 	E extends ElasticsearchIndexes,
@@ -448,7 +481,12 @@ export type ElasticsearchOutputFields<
 	Type extends "_source" | "fields",
 	//
 	RequestedFields = Type extends "_source"
-		? ExtractQuery_Source<QueryWithSource, E, Index>
+		? ExtractQuery_Source<
+				QueryWithSource,
+				E,
+				Index,
+				Index extends keyof E ? keyof E[Index] : PossibleFields<Index, E>
+			>
 		: ExtractQueryFields<QueryWithSource>,
 	// TODO: make this a union string instead of an object. we no longer need the values
 	Output = {
@@ -463,7 +501,7 @@ export type ElasticsearchOutputFields<
 		> as IsParentKeyALeaf<K, E, Index> extends true ? K : never]: FLAT_UNKNOWN;
 	},
 > = Type extends "_source"
-	? DeepPickPaths<E[Index], Extract<keyof Output, string>>
+	? DeepPickFieldsForIndex<E, Index, Extract<keyof Output, string>>
 	: {
 			[K in keyof Output as Output[K] extends FLAT_UNKNOWN
 				? RemoveLastDot<K>
@@ -573,38 +611,49 @@ type IssueWithReadonlyArray = "sort" | "query";
  * };
  * ```
  */
+type TypedSearchRequestForIndex<
+	Indexes extends ElasticsearchIndexes,
+	Index extends string,
+> = {
+	index: Index;
+	_source?:
+		| RArray<PossibleFieldsWithWildcards<Index, Indexes>>
+		| false
+		| {
+				includes?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
+				include?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
+				excludes?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
+				exclude?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
+		  };
+	fields?: RArray<
+		| PossibleFieldsWithWildcards<Index, Indexes, true>
+		| {
+				field: PossibleFieldsWithWildcards<Index, Indexes, true>;
+				format?: string;
+		  }
+	>;
+	docvalue_fields?: RArray<
+		| PossibleFieldsWithWildcards<Index, Indexes, true>
+		| {
+				field: PossibleFieldsWithWildcards<Index, Indexes, true>;
+				format?: string;
+		  }
+	>;
+};
+
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 	estypes.SearchRequest,
 	"index" | "_source" | "fields" | "docvalue_fields" | IssueWithReadonlyArray
 > &
-	{
-		[K in keyof Indexes]: {
-			index: K;
-			_source?:
-				| RArray<PossibleFieldsWithWildcards<K, Indexes>>
-				| false
-				| {
-						includes?: RArray<PossibleFieldsWithWildcards<K, Indexes>>;
-						include?: RArray<PossibleFieldsWithWildcards<K, Indexes>>;
-						excludes?: RArray<PossibleFieldsWithWildcards<K, Indexes>>;
-						exclude?: RArray<PossibleFieldsWithWildcards<K, Indexes>>;
-				  };
-			fields?: RArray<
-				| PossibleFieldsWithWildcards<K, Indexes, true>
-				| {
-						field: PossibleFieldsWithWildcards<K, Indexes, true>;
-						format?: string;
-				  }
-			>;
-			docvalue_fields?: RArray<
-				| PossibleFieldsWithWildcards<K, Indexes, true>
-				| {
-						field: PossibleFieldsWithWildcards<K, Indexes, true>;
-						format?: string;
-				  }
-			>;
-		};
-	}[keyof Indexes];
+	(
+		| {
+				[K in Extract<keyof Indexes, string>]: TypedSearchRequestForIndex<
+					Indexes,
+					K
+				>;
+		  }[Extract<keyof Indexes, string>]
+		| TypedSearchRequestForIndex<Indexes, AllIndex>
+	);
 
 export type ExtractAggs<V> = V extends
 	| { aggs: infer A }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -464,12 +464,28 @@ type IsParentKeyALeaf<
 			: false
 	: false;
 
+type DeepPickFieldsForAllIndex<
+	E extends ElasticsearchIndexes,
+	Paths extends string,
+> = {
+	[K in Extract<keyof E, string>]: Extract<
+		Paths,
+		PossibleFields<K, E>
+	> extends never
+		? {}
+		: DeepPickPaths<E[K], Extract<Paths, PossibleFields<K, E>>>;
+}[Extract<keyof E, string>];
+
 type DeepPickFieldsForIndex<
 	E extends ElasticsearchIndexes,
 	Index extends string,
 	Paths extends string,
 > = Index extends AllIndex
-	? E[Extract<keyof E, string>]
+	? [Paths] extends [PossibleFields<Index, E>]
+		? [PossibleFields<Index, E>] extends [Paths]
+			? E[Extract<keyof E, string>]
+			: DeepPickFieldsForAllIndex<E, Paths>
+		: DeepPickFieldsForAllIndex<E, Paths>
 	: Index extends keyof E
 		? DeepPickPaths<E[Index], Paths>
 		: never;

--- a/src/override/async-search-get-response.ts
+++ b/src/override/async-search-get-response.ts
@@ -1,6 +1,7 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
 	AggregationOutput,
+	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	ElasticsearchOutputFields,
 	ExtractAggsKey,
@@ -46,21 +47,22 @@ export type TypedAsyncSearchGetResponse<
 	Query extends SearchRequest,
 	E extends ElasticsearchIndexes,
 	Index extends string = RequestedIndex<Query>,
-> = Index extends keyof E
-	? OverrideAsyncSearchGetResponse<
-			Query,
-			E,
-			ElasticsearchOutputFields<Query, E, Index, "_source">,
-			ElasticsearchOutputFields<Query, E, Index, "fields">,
-			{
-				[K in ExtractAggsKey<Query>]: AggregationOutput<
-					Query,
-					Query,
-					E,
-					// @ts-expect-error: TODO
-					K,
-					Index
-				>;
-			}
-		>
-	: `Index '${Index}' not found`;
+> =
+	Index extends ElasticsearchIndex<E>
+		? OverrideAsyncSearchGetResponse<
+				Query,
+				E,
+				ElasticsearchOutputFields<Query, E, Index, "_source">,
+				ElasticsearchOutputFields<Query, E, Index, "fields">,
+				{
+					[K in ExtractAggsKey<Query>]: AggregationOutput<
+						Query,
+						Query,
+						E,
+						// @ts-expect-error: TODO
+						K,
+						Index
+					>;
+				}
+			>
+		: `Index '${Index}' not found`;

--- a/src/override/async-search-submit-response.ts
+++ b/src/override/async-search-submit-response.ts
@@ -1,6 +1,7 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
 	AggregationOutput,
+	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	ElasticsearchOutputFields,
 	ExtractAggsKey,
@@ -46,21 +47,22 @@ export type TypedAsyncSearchSubmitResponse<
 	Query extends SearchRequest,
 	E extends ElasticsearchIndexes,
 	Index extends string = RequestedIndex<Query>,
-> = Index extends keyof E
-	? OverrideAsyncSearchSubmitResponse<
-			Query,
-			E,
-			ElasticsearchOutputFields<Query, E, Index, "_source">,
-			ElasticsearchOutputFields<Query, E, Index, "fields">,
-			{
-				[K in ExtractAggsKey<Query>]: AggregationOutput<
-					Query,
-					Query,
-					E,
-					// @ts-expect-error: TODO
-					K,
-					Index
-				>;
-			}
-		>
-	: `Index '${Index}' not found`;
+> =
+	Index extends ElasticsearchIndex<E>
+		? OverrideAsyncSearchSubmitResponse<
+				Query,
+				E,
+				ElasticsearchOutputFields<Query, E, Index, "_source">,
+				ElasticsearchOutputFields<Query, E, Index, "fields">,
+				{
+					[K in ExtractAggsKey<Query>]: AggregationOutput<
+						Query,
+						Query,
+						E,
+						// @ts-expect-error: TODO
+						K,
+						Index
+					>;
+				}
+			>
+		: `Index '${Index}' not found`;

--- a/src/override/msearch-response.ts
+++ b/src/override/msearch-response.ts
@@ -1,5 +1,9 @@
 import type { estypes } from "@elastic/elasticsearch";
-import type { ElasticsearchIndexes, TypedSearchRequest } from "../lib";
+import type {
+	ElasticsearchIndex,
+	ElasticsearchIndexes,
+	TypedSearchRequest,
+} from "../lib";
 import type {
 	AlternatingPair,
 	IsNever,
@@ -11,7 +15,9 @@ import type {
 import type { TypedSearchResponse } from "./search-response";
 
 type PairType<E extends ElasticsearchIndexes> = {
-	header: Omit<estypes.MsearchMultisearchHeader, "index"> & { index?: keyof E };
+	header: Omit<estypes.MsearchMultisearchHeader, "index"> & {
+		index?: ElasticsearchIndex<E>;
+	};
 	request: Omit<TypedSearchRequest<E>, "index">;
 };
 type PopPair<Data> = Data extends [infer H, infer T, ...infer Rest]
@@ -51,7 +57,7 @@ export type TypedMsearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 	estypes.MsearchRequest,
 	"index" | "searches"
 > & {
-	index: keyof Indexes;
+	index: ElasticsearchIndex<Indexes>;
 	searches: MRequestSearches<Indexes>;
 };
 

--- a/src/override/search-response.ts
+++ b/src/override/search-response.ts
@@ -1,6 +1,7 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
 	AggregationOutput,
+	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	ElasticsearchOutputFields,
 	ExtractAggs,
@@ -109,21 +110,22 @@ export type TypedSearchResponse<
 	Query extends SearchRequest,
 	E extends ElasticsearchIndexes,
 	Index extends string = RequestedIndex<Query>,
-> = Index extends keyof E
-	? OverrideSearchResponse<
-			Query,
-			ElasticsearchOutputFields<Query, E, Index, "_source">,
-			ElasticsearchOutputFields<Query, E, Index, "fields">,
-			ExtractScriptFieldsKeys<Query>,
-			{
-				[K in ExtractAggsKey<Query>]: AggregationOutput<
-					Query,
-					Query,
-					E,
-					// @ts-expect-error: TODO
-					K,
-					Index
-				>;
-			}
-		>
-	: `Index '${Index}' not found`;
+> =
+	Index extends ElasticsearchIndex<E>
+		? OverrideSearchResponse<
+				Query,
+				ElasticsearchOutputFields<Query, E, Index, "_source">,
+				ElasticsearchOutputFields<Query, E, Index, "fields">,
+				ExtractScriptFieldsKeys<Query>,
+				{
+					[K in ExtractAggsKey<Query>]: AggregationOutput<
+						Query,
+						Query,
+						E,
+						// @ts-expect-error: TODO
+						K,
+						Index
+					>;
+				}
+			>
+		: `Index '${Index}' not found`;

--- a/tests/override/msearch-response.test.ts
+++ b/tests/override/msearch-response.test.ts
@@ -27,7 +27,7 @@ describe("msearch aggregation response types", () => {
 		>().toEqualTypeOf<CustomIndexes[keyof CustomIndexes]>();
 		expectTypeOf<
 			SuccessfulMsearchResponse<Responses[1]>["hits"]["hits"][0]["_source"]
-		>().toEqualTypeOf<CustomIndexes[keyof CustomIndexes]>();
+		>().toEqualTypeOf<Pick<CustomIndexes["demo"], "score"> | {}>();
 	});
 
 	test("preserves different aggregations per search", () => {

--- a/tests/override/msearch-response.test.ts
+++ b/tests/override/msearch-response.test.ts
@@ -11,6 +11,25 @@ type SuccessfulMsearchResponse<T> = Extract<
 >;
 
 describe("msearch aggregation response types", () => {
+	test("supports _all index", () => {
+		const query = {
+			index: "_all",
+			searches: [{ index: "_all" }, {}, {}, { _source: ["score"] }],
+		} as const satisfies TypedMsearchRequest<CustomIndexes>;
+
+		type Responses = TypedMSearchResponse<
+			typeof query,
+			CustomIndexes
+		>["responses"];
+
+		expectTypeOf<
+			SuccessfulMsearchResponse<Responses[0]>["hits"]["hits"][0]["_source"]
+		>().toEqualTypeOf<CustomIndexes[keyof CustomIndexes]>();
+		expectTypeOf<
+			SuccessfulMsearchResponse<Responses[1]>["hits"]["hits"][0]["_source"]
+		>().toEqualTypeOf<CustomIndexes[keyof CustomIndexes]>();
+	});
+
 	test("preserves different aggregations per search", () => {
 		const query = {
 			index: "demo",

--- a/tests/override/search-response.test.ts
+++ b/tests/override/search-response.test.ts
@@ -24,6 +24,20 @@ describe("Should return the correct type", () => {
 				expectTypeOf<Output>().toEqualTypeOf<CustomIndexes["demo"]>();
 			});
 
+			test("with _all index", () => {
+				const query = typedEs(client, {
+					index: "_all",
+				});
+				type Output = TypedSearchResponse<
+					typeof query,
+					CustomIndexes
+				>["hits"]["hits"][0]["_source"];
+
+				expectTypeOf<Output>().toEqualTypeOf<
+					CustomIndexes[keyof CustomIndexes]
+				>();
+			});
+
 			describe("handle custom fields", () => {
 				describe("on direct values", () => {
 					// not an object

--- a/tests/typed-es.test.ts
+++ b/tests/typed-es.test.ts
@@ -19,6 +19,13 @@ describe("typedEs Function", () => {
 				_source: [],
 			});
 		});
+
+		test("with _all index", () => {
+			const query = typedEs(client, {
+				index: "_all",
+			});
+			expectTypeOf<RequestedIndex<typeof query>>().toEqualTypeOf<"_all">();
+		});
 	});
 
 	describe("Should enforce correct _source", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `_all` as a typed search index target, enabling queries across all indices while maintaining full type safety and automatic field resolution across all available mappings.

* **Tests**
  * Added comprehensive test coverage for `_all` index functionality to verify type inference, field resolution, and response typing across multiple indices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vahor/typed-es/pull/377)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->