### PR TITLE
fix: support index lists

### DIFF
--- a/.changeset/support-index-lists.md
+++ b/.changeset/support-index-lists.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add typed search and msearch support for index lists.

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ const result = await (client as unknown as Client).search<TDocument, TAggregatio
 - Some aggregation functions might be missing.
 - `_source` accepts arbitrary strings to support wildcards. Wildcards still produce the **correct inferred output type**.
 - Client setup currently requires `as unknown as TypedClient<Indexes>` because the official client types are being augmented.
-- `index` must be a concrete string key. Wildcard index names and `_all` are not supported yet.
+- `index` must be a concrete key or a list of concrete keys. Wildcard index names and `_all` are not supported yet.
 
 PRs are welcome to fix these limitations.
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ const result = await (client as unknown as Client).search<TDocument, TAggregatio
 - Some aggregation functions might be missing.
 - `_source` accepts arbitrary strings to support wildcards. Wildcards still produce the **correct inferred output type**.
 - Client setup currently requires `as unknown as TypedClient<Indexes>` because the official client types are being augmented.
-- `index` must be a concrete key or a list of concrete keys. Wildcard index names and `_all` are not supported yet.
+- `index` must be a concrete key, `_all`, or a list of concrete keys. Wildcard index names are not supported yet.
 
 PRs are welcome to fix these limitations.
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -34,7 +34,8 @@ type WithVariants<T extends string> = `${T}.${string}` | T;
 type AllIndex = "_all";
 export type ElasticsearchIndex<Indexes extends ElasticsearchIndexes> =
 	| Extract<keyof Indexes, string>
-	| AllIndex;
+	| AllIndex
+	| RArray<Extract<keyof Indexes, string>>;
 
 type FilterToOnlyLeaf<
 	T extends string,
@@ -222,10 +223,14 @@ export type TypeOfField<
 		? RecursiveDotNotation<Indexes[Index], Field>
 		: never;
 
+type RequestedIndexValue<Index> = Index extends string
+	? Index
+	: Index extends RArray<infer I extends string>
+		? I
+		: never;
+
 export type RequestedIndex<Query> = "index" extends keyof Query
-	? Query["index"] extends string
-		? Query["index"]
-		: never
+	? RequestedIndexValue<NonNullable<Query["index"]>>
 	: never;
 
 export type HasOption<
@@ -476,6 +481,18 @@ type DeepPickFieldsForAllIndex<
 		: DeepPickPaths<E[K], Extract<Paths, PossibleFields<K, E>>>;
 }[Extract<keyof E, string>];
 
+type DeepPickPathsForIndex<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Paths extends string,
+> = Paths extends string
+	? IsNever<TypeOfField<Paths, E, Index>> extends false
+		? Paths
+		: IsParentKeyALeaf<Paths, E, Index> extends true
+			? Paths
+			: never
+	: never;
+
 type DeepPickFieldsForIndex<
 	E extends ElasticsearchIndexes,
 	Index extends string,
@@ -487,7 +504,7 @@ type DeepPickFieldsForIndex<
 			: DeepPickFieldsForAllIndex<E, Paths>
 		: DeepPickFieldsForAllIndex<E, Paths>
 	: Index extends keyof E
-		? DeepPickPaths<E[Index], Paths>
+		? DeepPickPaths<E[Index], DeepPickPathsForIndex<E, Index, Paths>>
 		: never;
 
 export type ElasticsearchOutputFields<
@@ -630,8 +647,9 @@ type IssueWithReadonlyArray = "sort" | "query";
 type TypedSearchRequestForIndex<
 	Indexes extends ElasticsearchIndexes,
 	Index extends string,
+	IndexInput = Index,
 > = {
-	index: Index;
+	index: IndexInput;
 	_source?:
 		| RArray<PossibleFieldsWithWildcards<Index, Indexes>>
 		| false
@@ -669,6 +687,11 @@ export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 				>;
 		  }[Extract<keyof Indexes, string>]
 		| TypedSearchRequestForIndex<Indexes, AllIndex>
+		| TypedSearchRequestForIndex<
+				Indexes,
+				Extract<keyof Indexes, string>,
+				RArray<Extract<keyof Indexes, string>>
+		  >
 	);
 
 export type ExtractAggs<V> = V extends

--- a/src/override/msearch-response.ts
+++ b/src/override/msearch-response.ts
@@ -2,6 +2,7 @@ import type { estypes } from "@elastic/elasticsearch";
 import type {
 	ElasticsearchIndex,
 	ElasticsearchIndexes,
+	RequestedIndex,
 	TypedSearchRequest,
 } from "../lib";
 import type {
@@ -74,9 +75,11 @@ type ParsedSearches<
 		? never
 		: P[index] extends { data: PairType<E> }
 			? {
-					Index: P[index]["data"]["header"]["index"] extends string
-						? P[index]["data"]["header"]["index"]
-						: Query["index"];
+					Index: IsNever<
+						RequestedIndex<P[index]["data"]["header"]>
+					> extends true
+						? RequestedIndex<Query>
+						: RequestedIndex<P[index]["data"]["header"]>;
 					Query: P[index]["data"]["request"];
 				}
 			: never;

--- a/tests/override/msearch-response.test.ts
+++ b/tests/override/msearch-response.test.ts
@@ -30,6 +30,25 @@ describe("msearch aggregation response types", () => {
 		>().toEqualTypeOf<Pick<CustomIndexes["demo"], "score"> | {}>();
 	});
 
+	test("supports index lists", () => {
+		const query = {
+			index: ["demo", "orders"],
+			searches: [{}, {}, { index: ["issues", "reviews"] }, {}],
+		} as const satisfies TypedMsearchRequest<CustomIndexes>;
+
+		type Responses = TypedMSearchResponse<
+			typeof query,
+			CustomIndexes
+		>["responses"];
+
+		expectTypeOf<
+			SuccessfulMsearchResponse<Responses[0]>["hits"]["hits"][0]["_source"]
+		>().toEqualTypeOf<CustomIndexes["demo"] | CustomIndexes["orders"]>();
+		expectTypeOf<
+			SuccessfulMsearchResponse<Responses[1]>["hits"]["hits"][0]["_source"]
+		>().toEqualTypeOf<CustomIndexes["issues"] | CustomIndexes["reviews"]>();
+	});
+
 	test("preserves different aggregations per search", () => {
 		const query = {
 			index: "demo",

--- a/tests/override/search-response.test.ts
+++ b/tests/override/search-response.test.ts
@@ -68,6 +68,21 @@ describe("Should return the correct type", () => {
 				>();
 			});
 
+			test("with index list and shared selected _source field", () => {
+				const query = typedEs(client, {
+					index: ["orders", "issues"],
+					_source: ["id"],
+				});
+				type Output = TypedSearchResponse<
+					typeof query,
+					CustomIndexes
+				>["hits"]["hits"][0]["_source"];
+
+				expectTypeOf<Output>().toEqualTypeOf<{
+					id: string;
+				}>();
+			});
+
 			describe("handle custom fields", () => {
 				describe("on direct values", () => {
 					// not an object

--- a/tests/override/search-response.test.ts
+++ b/tests/override/search-response.test.ts
@@ -38,6 +38,36 @@ describe("Should return the correct type", () => {
 				>();
 			});
 
+			test("with index list", () => {
+				const query = typedEs(client, {
+					index: ["demo", "orders"],
+				});
+				type Output = TypedSearchResponse<
+					typeof query,
+					CustomIndexes
+				>["hits"]["hits"][0]["_source"];
+
+				expectTypeOf<Output>().toEqualTypeOf<
+					CustomIndexes["demo"] | CustomIndexes["orders"]
+				>();
+			});
+
+			test("with index list and selected _source fields", () => {
+				const query = typedEs(client, {
+					index: ["demo", "orders"],
+					_source: ["score", "status"],
+				});
+				type Output = TypedSearchResponse<
+					typeof query,
+					CustomIndexes
+				>["hits"]["hits"][0]["_source"];
+
+				expectTypeOf<Output>().toEqualTypeOf<
+					| { score: CustomIndexes["demo"]["score"] }
+					| { status: CustomIndexes["orders"]["status"] }
+				>();
+			});
+
 			describe("handle custom fields", () => {
 				describe("on direct values", () => {
 					// not an object

--- a/tests/typed-es.test.ts
+++ b/tests/typed-es.test.ts
@@ -26,6 +26,24 @@ describe("typedEs Function", () => {
 			});
 			expectTypeOf<RequestedIndex<typeof query>>().toEqualTypeOf<"_all">();
 		});
+
+		test("with valid index list", () => {
+			const query = typedEs(client, {
+				index: ["demo", "orders"],
+				_source: [],
+			});
+			expectTypeOf<RequestedIndex<typeof query>>().toEqualTypeOf<
+				"demo" | "orders"
+			>();
+		});
+
+		test("with invalid index list", () => {
+			typedEs(client, {
+				// @ts-expect-error: 'invalid' is not a valid index
+				index: ["demo", "invalid"],
+				_source: [],
+			});
+		});
 	});
 
 	describe("Should enforce correct _source", () => {


### PR DESCRIPTION
## Summary
- allow typed search requests to target a list of concrete indexes
- infer search and msearch response sources from the selected index list
- update the limitation note and add a patch changeset

## Notes
- This intentionally does not add wildcard index or `_all` support.

Closes #298