### PR TITLE
fix: add cumulative cardinality aggregation

### DIFF
--- a/.changeset/cumulative-cardinality.md
+++ b/.changeset/cumulative-cardinality.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for the `cumulative_cardinality` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ npm install -D @vahor/typed-es
 | Bucket Selector | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
 | Bucket Sort | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |
 | Change Point | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
-| Cumulative Cardinality | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation) |
+| Cumulative Cardinality | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation) |
 | Cumulative Sum | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-sum-aggregation) |
 | Derivative | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-derivative-aggregation) |
 | Extended Stats Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-extended-stats-bucket-aggregation) |

--- a/src/aggregations/pipeline/cumulative_cardinality.ts
+++ b/src/aggregations/pipeline/cumulative_cardinality.ts
@@ -1,0 +1,11 @@
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation
+ */
+export type CumulativeCardinality<Agg> = Agg extends {
+	cumulative_cardinality: { buckets_path: string };
+}
+	? {
+			value: number;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/aggregations/pipeline/index.ts
+++ b/src/aggregations/pipeline/index.ts
@@ -2,6 +2,7 @@ export * from "./avg_bucket";
 export * from "./bucket_correlation";
 export * from "./bucket_count_ks_test";
 export * from "./bucket_script";
+export * from "./cumulative_cardinality";
 export * from "./cumulative_sum";
 export * from "./derivative";
 export * from "./extended_stats_bucket";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -313,6 +313,7 @@ export type NextAggsParentKey<
 	| "bucket_correlation"
 	| "bucket_count_ks_test"
 	| "bucket_script"
+	| "cumulative_cardinality"
 	| "cumulative_sum"
 	| "derivative"
 	| "stats_bucket"
@@ -395,6 +396,7 @@ export type AggregationOutput<
 				| Pipeline.BucketCorrelation<Agg>
 				| Pipeline.BucketCountKSTest<Agg>
 				| Pipeline.BucketScript<Agg>
+				| Pipeline.CumulativeCardinality<Agg>
 				| Pipeline.CumulativeSum<Agg>
 				| Pipeline.Derivative<Agg>
 				| Pipeline.ExtendedStatsBucket<Agg>

--- a/tests/aggregations/pipeline/cumulative_cardinality.test.ts
+++ b/tests/aggregations/pipeline/cumulative_cardinality.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 
@@ -26,10 +24,34 @@ describe("Cumulative Cardinality Pipeline Aggregation", () => {
 					key_as_string: string;
 					key: number;
 					doc_count: number;
-					distinct_users: { value: number };
+					distinct_users: { value: number; value_as_string?: string };
 					total_new_users: { value: number; value_as_string?: string };
 				}>;
 			};
 		}>();
+	});
+
+	test("supports optional format", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				users_per_day: {
+					date_histogram: { field: "date"; calendar_interval: "day" };
+					aggs: {
+						distinct_users: { cardinality: { field: "entity_id" } };
+						total_new_users: {
+							cumulative_cardinality: {
+								buckets_path: "distinct_users";
+								format: "#,###";
+							};
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<
+			Aggregations["aggregations"]["users_per_day"]["buckets"][number]["total_new_users"]
+		>().toEqualTypeOf<{ value: number; value_as_string?: string }>();
 	});
 });


### PR DESCRIPTION
## Summary
- add the `cumulative_cardinality` pipeline aggregation output type
- enable the existing docs-based cumulative cardinality test and cover `format`
- mark Cumulative Cardinality as supported in the README aggregation table
- add a patch changeset

## Notes
- `cumulative_cardinality` outputs `{ value: number; value_as_string?: string }`, matching the docs response shape and optional `format` behavior.

Closes #268
