### PR TITLE
test: enable bucket selector aggregation

### DIFF
--- a/.changeset/bucket-selector.md
+++ b/.changeset/bucket-selector.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Mark `bucket_selector` aggregation support as implemented with type coverage for its output shape.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ npm install -D @vahor/typed-es
 | Bucket Script | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-script-aggregation) |
 | Bucket Count K-S Test | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-count-ks-test-aggregation) |
 | Bucket Correlation | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
-| Bucket Selector | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
+| Bucket Selector | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
 | Bucket Sort | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |
 | Change Point | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
 | Cumulative Cardinality | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation) |

--- a/tests/aggregations/pipeline/bucket_selector.test.ts
+++ b/tests/aggregations/pipeline/bucket_selector.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
 import type { TestAggregationOutput } from "../../shared";
 


### PR DESCRIPTION
## Summary
- enable the `bucket_selector` aggregation type test based on the Elasticsearch docs example
- mark Bucket Selector as implemented in the README aggregation table
- add a patch changeset

## Notes
- `bucket_selector` filters parent buckets and does not add its own response entry, matching the documented response shape.

Closes #243