### PR TITLE
feat: add change point aggregation

### DIFF
--- a/.changeset/change-point-aggregation.md
+++ b/.changeset/change-point-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add support for the `change_point` pipeline aggregation.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,11 +43,12 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - name: Remove incompatible tests for v8 (catesian)
+      - name: Remove incompatible tests for v8
         if: matrix.elasticsearch-version == '^8'
         run: |
           rm -f tests/aggregations/metrics/cartesian_bounds.test.ts
           rm -f tests/aggregations/metrics/cartesian_centroid.test.ts
+          rm -f tests/aggregations/pipeline/change_point.test.ts
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Elasticsearch ${{ matrix.elasticsearch-version }}

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm install -D @vahor/typed-es
 | Bucket Correlation | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-correlation-aggregation) |
 | Bucket Selector | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation) |
 | Bucket Sort | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-sort-aggregation) |
-| Change Point | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
+| Change Point | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation) |
 | Cumulative Cardinality | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-cardinality-aggregation) |
 | Cumulative Sum | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-cumulative-sum-aggregation) |
 | Derivative | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-derivative-aggregation) |

--- a/src/aggregations/bucket/adjacency_matrix.ts
+++ b/src/aggregations/bucket/adjacency_matrix.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Combinations, PrettyArray } from "../../types/helpers";
+import type { KeyedBucketBase } from "../helpers";
 
 type DefaultSeparator = "&";
 type GetSeparator<S> = S extends string ? S : DefaultSeparator;
@@ -21,10 +22,10 @@ export type AdjacencyMatrix<
 	? Filters extends Record<infer Keys, unknown>
 		? {
 				buckets: PrettyArray<
-					{
-						key: Combinations<Extract<Keys, string>, GetSeparator<Separator>>;
-						doc_count: number;
-					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+					KeyedBucketBase<
+						Combinations<Extract<Keys, string>, GetSeparator<Separator>>
+					> &
+						AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
 			}
 		: never

--- a/src/aggregations/bucket/auto_date_histogram.ts
+++ b/src/aggregations/bucket/auto_date_histogram.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-autodatehistogram-aggregation
@@ -21,10 +21,8 @@ export type AutoDateHistogram<
 			Agg,
 			{
 				buckets: PrettyArray<
-					{
+					KeyedBucketBase<number> & {
 						key_as_string: string;
-						key: number;
-						doc_count: number;
 					} & AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
 				interval: string;

--- a/src/aggregations/bucket/categorize_text.ts
+++ b/src/aggregations/bucket/categorize_text.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-categorize-text-aggregation
@@ -18,9 +18,7 @@ export type CategorizeText<
 			string,
 			{
 				buckets: PrettyArray<
-					{
-						key: string;
-						doc_count: number;
+					KeyedBucketBase<string> & {
 						max_matching_length: number;
 						regex: string;
 					} & AppendSubAggs<BaseQuery, E, Index, Agg>

--- a/src/aggregations/bucket/children.ts
+++ b/src/aggregations/bucket/children.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html
@@ -10,9 +11,5 @@ export type Children<
 	Index extends string,
 	Agg,
 > = Agg extends { children: { type: string } }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/composite.ts
+++ b/src/aggregations/bucket/composite.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
+import type { KeyedBucketBase } from "../helpers";
 
 type CompositeSources = Array<Record<string, unknown>>;
 
@@ -21,10 +22,8 @@ export type Composite<
 	? {
 			after_key: Record<ExtractSourcesKeys<Sources>, unknown>;
 			buckets: PrettyArray<
-				{
-					key: Record<ExtractSourcesKeys<Sources>, unknown>;
-					doc_count: number;
-				} & AppendSubAggs<BaseQuery, E, Index, Agg>
+				KeyedBucketBase<Record<ExtractSourcesKeys<Sources>, unknown>> &
+					AppendSubAggs<BaseQuery, E, Index, Agg>
 			>;
 		}
 	: never;

--- a/src/aggregations/bucket/date_histogram.ts
+++ b/src/aggregations/bucket/date_histogram.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
-import type { PrettyArray } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { Prettify, PrettyArray } from "../../types/helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation
@@ -24,20 +24,18 @@ export type DateHistogram<
 				? {
 						buckets: Record<
 							string,
-							{
-								key_as_string: string;
-								key: number;
-								doc_count: number;
-							} & AppendSubAggs<BaseQuery, E, Index, Agg>
+							Prettify<
+								KeyedBucketBase<number> & {
+									key_as_string: string;
+								} & AppendSubAggs<BaseQuery, E, Index, Agg>
+							>
 						>;
 					}
 				: // array default (keyed: false)
 					{
 						buckets: PrettyArray<
-							{
+							KeyedBucketBase<number> & {
 								key_as_string: string;
-								key: number;
-								doc_count: number;
 							} & AppendSubAggs<BaseQuery, E, Index, Agg>
 						>;
 					},

--- a/src/aggregations/bucket/date_range.ts
+++ b/src/aggregations/bucket/date_range.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { KeyedArrayToObject, Prettify } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 type RangeSpec = {
 	from?: string | undefined;
@@ -22,12 +22,11 @@ type RangeOutput<
 		key?: infer CustomKey;
 	}
 		? Prettify<
-				{
-					key: undefined extends CustomKey
+				KeyedBucketBase<
+					undefined extends CustomKey
 						? `${FormatToKey<F>}-${FormatToKey<T>}`
-						: CustomKey;
-					doc_count: number;
-				} & {
+						: CustomKey
+				> & {
 					[K in "from" | "from_as_string" as F extends string
 						? K
 						: never]: K extends "from_as_string" ? string : number;

--- a/src/aggregations/bucket/diversified_sampler.ts
+++ b/src/aggregations/bucket/diversified_sampler.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-diversified-sampler-aggregation
@@ -10,9 +11,5 @@ export type DiversifiedSampler<
 	Index extends string,
 	Agg,
 > = Agg extends { diversified_sampler: object }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/filter.ts
+++ b/src/aggregations/bucket/filter.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-filter-aggregation
@@ -10,9 +11,5 @@ export type Filter<
 	Index extends string,
 	Agg,
 > = Agg extends { filter: object }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/filters.ts
+++ b/src/aggregations/bucket/filters.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify, PrettyArray } from "../../types/helpers";
+import type { BucketBase, KeyedBucketBase } from "../helpers";
 
 type KeysAndOBK<Keys, Agg> = Agg extends {
 	filters: { other_bucket_key: infer OBK extends string };
@@ -25,9 +26,7 @@ export type Filters<
 		? // Anonymous filters (array format)
 			{
 				buckets: PrettyArray<
-					{
-						doc_count: number;
-					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+					BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
 			}
 		: Filters extends Record<infer Keys, unknown>
@@ -35,17 +34,14 @@ export type Filters<
 				Keyed extends false
 				? {
 						buckets: PrettyArray<
-							{
-								key: KeysAndOBK<Keys, Agg>;
-								doc_count: number;
-							} & AppendSubAggs<BaseQuery, E, Index, Agg>
+							KeyedBucketBase<KeysAndOBK<Keys, Agg>> &
+								AppendSubAggs<BaseQuery, E, Index, Agg>
 						>;
 					}
 				: {
 						buckets: Prettify<{
-							[K in KeysAndOBK<Keys, Agg>]: {
-								doc_count: number;
-							} & AppendSubAggs<BaseQuery, E, Index, Agg>;
+							[K in KeysAndOBK<Keys, Agg>]: BucketBase &
+								AppendSubAggs<BaseQuery, E, Index, Agg>;
 						}>;
 					}
 			: never

--- a/src/aggregations/bucket/frequent_item_sets.ts
+++ b/src/aggregations/bucket/frequent_item_sets.ts
@@ -5,6 +5,7 @@ import type {
 	TypeOfField,
 } from "../..";
 import type { PrettyArray } from "../../types/helpers";
+import type { KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-frequent-item-sets-aggregation
@@ -21,11 +22,9 @@ export type FrequentItemSets<
 }
 	? {
 			buckets: PrettyArray<
-				{
-					key: {
-						[K in Fields[number]["field"]]: TypeOfField<K, E, Index>[];
-					};
-					doc_count: number;
+				KeyedBucketBase<{
+					[K in Fields[number]["field"]]: TypeOfField<K, E, Index>[];
+				}> & {
 					support: number;
 				} & AppendSubAggs<BaseQuery, E, Index, Agg>
 			>;

--- a/src/aggregations/bucket/geohash_grid.ts
+++ b/src/aggregations/bucket/geohash_grid.ts
@@ -3,6 +3,7 @@ import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 import type {
 	AggregationFieldResult,
 	AggregationPropertyTypeResult,
+	KeyedBucketBase,
 } from "../helpers";
 
 type DefaultPrecision = 5;
@@ -34,10 +35,7 @@ export type GeoHashGrid<
 				Range_1_12,
 				{
 					buckets: PrettyArray<
-						{
-							key: string;
-							doc_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
+						KeyedBucketBase<string> & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				},
 				GetPrecision<Precision>

--- a/src/aggregations/bucket/geohex_grid.ts
+++ b/src/aggregations/bucket/geohex_grid.ts
@@ -3,6 +3,7 @@ import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 import type {
 	AggregationFieldResult,
 	AggregationPropertyTypeResult,
+	KeyedBucketBase,
 } from "../helpers";
 
 type DefaultPrecision = 6;
@@ -34,10 +35,7 @@ export type GeoHexGrid<
 				Range_0_15,
 				{
 					buckets: PrettyArray<
-						{
-							key: string;
-							doc_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
+						KeyedBucketBase<string> & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				},
 				GetPrecision<Precision>

--- a/src/aggregations/bucket/geotile_grid.ts
+++ b/src/aggregations/bucket/geotile_grid.ts
@@ -3,6 +3,7 @@ import type { PrettyArray, RangeInclusive } from "../../types/helpers";
 import type {
 	AggregationFieldResult,
 	AggregationPropertyTypeResult,
+	KeyedBucketBase,
 } from "../helpers";
 
 type DefaultPrecision = 7;
@@ -34,10 +35,8 @@ export type GeoTileGrid<
 				Range_0_29,
 				{
 					buckets: PrettyArray<
-						{
-							key: `${GetPrecision<Precision>}/${number}/${number}`;
-							doc_count: number;
-						} & AppendSubAggs<BaseQuery, E, Index, Agg>
+						KeyedBucketBase<`${GetPrecision<Precision>}/${number}/${number}`> &
+							AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				},
 				GetPrecision<Precision>

--- a/src/aggregations/bucket/global.ts
+++ b/src/aggregations/bucket/global.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-global-aggregation
@@ -10,9 +11,5 @@ export type Global<
 	Index extends string,
 	Agg,
 > = Agg extends { global: object }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/histogram.ts
+++ b/src/aggregations/bucket/histogram.ts
@@ -1,15 +1,12 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 type HistogramAggOutput<
 	BaseQuery extends SearchRequest,
 	E extends ElasticsearchIndexes,
 	Index extends string,
 	Agg extends Record<string, unknown>,
-> = {
-	key: number;
-	doc_count: number;
-} & AppendSubAggs<BaseQuery, E, Index, Agg>;
+> = KeyedBucketBase<number> & AppendSubAggs<BaseQuery, E, Index, Agg>;
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-histogram-aggregation

--- a/src/aggregations/bucket/ip_prefix.ts
+++ b/src/aggregations/bucket/ip_prefix.ts
@@ -7,7 +7,7 @@ import type {
 	KeyedArrayToObject,
 	PrettyArray,
 } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 type IpPrefixOutput<
 	BaseQuery extends SearchRequest,
@@ -19,15 +19,15 @@ type IpPrefixOutput<
 	PrefixLength extends number,
 	IsIpv6,
 > = PrettyArray<
-	{
-		key: AppendPrefixLength extends true
+	KeyedBucketBase<
+		AppendPrefixLength extends true
 			? IsIpv6 extends true
 				? CidrIpv6<PrefixLength>
 				: CidrIpv4<PrefixLength>
 			: IsIpv6 extends true
 				? Ipv6
-				: Ipv4;
-		doc_count: number;
+				: Ipv4
+	> & {
 		is_ipv6: IsIpv6 extends true ? true : false;
 		prefix_length: PrefixLength;
 	} & {

--- a/src/aggregations/bucket/ip_range.ts
+++ b/src/aggregations/bucket/ip_range.ts
@@ -9,7 +9,7 @@ import type {
 	KeyedArrayToObject,
 	Prettify,
 } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 type IpRangeSpec =
 	| AtLeastOneOf<
@@ -41,14 +41,13 @@ type IpRangeOutput<
 		key?: infer K;
 	}
 		? Prettify<
-				{
-					key: K extends string
+				KeyedBucketBase<
+					K extends string
 						? K
 						: M extends string
 							? M
-							: `${FormatToKey<F>}-${FormatToKey<T>}`;
-					doc_count: number;
-				} & {
+							: `${FormatToKey<F>}-${FormatToKey<T>}`
+				> & {
 					[K in "from" as F extends string
 						? K
 						: M extends string

--- a/src/aggregations/bucket/missing.ts
+++ b/src/aggregations/bucket/missing.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-missing-aggregation
@@ -10,9 +11,5 @@ export type Missing<
 	Index extends string,
 	Agg,
 > = Agg extends { missing: object }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/multi_terms.ts
+++ b/src/aggregations/bucket/multi_terms.ts
@@ -5,7 +5,7 @@ import type {
 	TypeOfField,
 } from "../../";
 import type { PrettyArray, SeparatedString } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-multi-terms-aggregation
@@ -27,10 +27,8 @@ export type MultiTerms<
 					doc_count_error_upper_bound: number;
 					sum_other_doc_count: number;
 					buckets: PrettyArray<
-						{
-							key: Array<TypeOfField<Field, E, Index>>;
+						KeyedBucketBase<Array<TypeOfField<Field, E, Index>>> & {
 							key_as_string: SeparatedString<"|", Terms["length"]>;
-							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>;
 				},

--- a/src/aggregations/bucket/nested.ts
+++ b/src/aggregations/bucket/nested.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
@@ -10,9 +11,5 @@ export type Nested<
 	Index extends string,
 	Agg,
 > = Agg extends { nested: { path: string } }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/parent.ts
+++ b/src/aggregations/bucket/parent.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-parent-aggregation.html
@@ -10,9 +11,5 @@ export type Parent<
 	Index extends string,
 	Agg,
 > = Agg extends { parent: { type: string } }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/random_sampler.ts
+++ b/src/aggregations/bucket/random_sampler.ts
@@ -5,6 +5,7 @@ import type {
 	SearchRequest,
 } from "../..";
 import type { IsNumericLiteral, Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * Valid probability range for `random_sampler` aggregation.
@@ -50,11 +51,7 @@ export type RandomSampler<
 	Agg,
 > = Agg extends { random_sampler: { probability: infer P } }
 	? ValidateProbability<P> extends true
-		? Prettify<
-				{
-					doc_count: number;
-				} & AppendSubAggs<BaseQuery, E, Index, Agg>
-			>
+		? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 		: InvalidPropertyTypeInAggregation<
 				"probability",
 				Agg,
@@ -62,9 +59,5 @@ export type RandomSampler<
 				ValidProbabilityRange
 			>
 	: Agg extends { random_sampler: object }
-		? Prettify<
-				{
-					doc_count: number;
-				} & AppendSubAggs<BaseQuery, E, Index, Agg>
-			>
+		? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 		: never;

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -6,7 +6,7 @@ import type {
 	ToDecimal,
 	ToString,
 } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 type RangeSpec = {
 	from?: number | undefined;
@@ -33,10 +33,9 @@ type RangeOutput<
 		key?: infer K;
 	}
 		? Prettify<
-				{
-					key: K extends string ? K : `${FormatToKey<F>}-${FormatToKey<T>}`;
-					doc_count: number;
-				} & {
+				KeyedBucketBase<
+					K extends string ? K : `${FormatToKey<F>}-${FormatToKey<T>}`
+				> & {
 					[K in "from" as F extends number ? K : never]: F;
 				} & {
 					[K in "to" as T extends number ? K : never]: T;

--- a/src/aggregations/bucket/rare_terms.ts
+++ b/src/aggregations/bucket/rare_terms.ts
@@ -5,7 +5,7 @@ import type {
 	TypeOfField,
 } from "../..";
 import type { IsStringLiteral, PrettyArray } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-rare-terms-aggregation
@@ -22,15 +22,14 @@ export type RareTerms<
 			Agg,
 			{
 				buckets: PrettyArray<
-					{
-						// TODO: should probably add a helper for this kind of thing
-						key: number extends TypeOfField<Field, E, Index>
+					KeyedBucketBase<
+						number extends TypeOfField<Field, E, Index>
 							? number
 							: IsStringLiteral<TypeOfField<Field, E, Index>> extends true
 								? TypeOfField<Field, E, Index>
-								: string | number;
-						doc_count: number;
-					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+								: string | number
+					> &
+						AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
 			},
 			Field

--- a/src/aggregations/bucket/reverse_nested.ts
+++ b/src/aggregations/bucket/reverse_nested.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-reverse-nested-aggregation
@@ -10,9 +11,5 @@ export type ReverseNested<
 	Index extends string,
 	Agg,
 > = Agg extends { reverse_nested: { path?: string } }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/sampler.ts
+++ b/src/aggregations/bucket/sampler.ts
@@ -1,5 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-sampler-aggregation
@@ -10,9 +11,5 @@ export type Sampler<
 	Index extends string,
 	Agg,
 > = Agg extends { sampler: object }
-	? Prettify<
-			{
-				doc_count: number;
-			} & AppendSubAggs<BaseQuery, E, Index, Agg>
-		>
+	? Prettify<BucketBase & AppendSubAggs<BaseQuery, E, Index, Agg>>
 	: never;

--- a/src/aggregations/bucket/significant_terms.ts
+++ b/src/aggregations/bucket/significant_terms.ts
@@ -3,8 +3,12 @@ import type {
 	ElasticsearchIndexes,
 	SearchRequest,
 } from "../../";
-import type { PrettyArray } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type { Prettify, PrettyArray } from "../../types/helpers";
+import type {
+	AggregationFieldTypeResult,
+	BucketBase,
+	KeyedBucketBase,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significantterms-aggregation
@@ -20,18 +24,17 @@ export type SignificantTerms<
 			Index,
 			Agg,
 			string,
-			{
-				doc_count: number;
-				bg_count: number;
-				buckets: PrettyArray<
-					{
-						key: string;
-						doc_count: number;
-						score: number;
-						bg_count: number;
-					} & AppendSubAggs<BaseQuery, E, Index, Agg>
-				>;
-			},
+			Prettify<
+				BucketBase & {
+					bg_count: number;
+					buckets: PrettyArray<
+						KeyedBucketBase<string> & {
+							score: number;
+							bg_count: number;
+						} & AppendSubAggs<BaseQuery, E, Index, Agg>
+					>;
+				}
+			>,
 			Field
 		>
 	: never;

--- a/src/aggregations/bucket/significant_text.ts
+++ b/src/aggregations/bucket/significant_text.ts
@@ -1,6 +1,10 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
-import type { PrettyArray } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type { Prettify, PrettyArray } from "../../types/helpers";
+import type {
+	AggregationFieldTypeResult,
+	BucketBase,
+	KeyedBucketBase,
+} from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significanttext-aggregation
@@ -16,17 +20,16 @@ export type SignificantText<
 			Index,
 			Agg,
 			string,
-			{
-				doc_count: number;
-				buckets: PrettyArray<
-					{
-						key: string;
-						doc_count: number;
-						score: number;
-						bg_count: number;
-					} & AppendSubAggs<BaseQuery, E, Index, Agg>
-				>;
-			},
+			Prettify<
+				BucketBase & {
+					buckets: PrettyArray<
+						KeyedBucketBase<string> & {
+							score: number;
+							bg_count: number;
+						} & AppendSubAggs<BaseQuery, E, Index, Agg>
+					>;
+				}
+			>,
 			Field
 		>
 	: never;

--- a/src/aggregations/bucket/terms.ts
+++ b/src/aggregations/bucket/terms.ts
@@ -5,7 +5,7 @@ import type {
 	TypeOfField,
 } from "../..";
 import type { IsStringLiteral, PrettyArray } from "../../types/helpers";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-terms-aggregation
@@ -24,14 +24,14 @@ export type Terms<
 				doc_count_error_upper_bound: number;
 				sum_other_doc_count: number;
 				buckets: PrettyArray<
-					{
-						key: number extends TypeOfField<Field, E, Index>
+					KeyedBucketBase<
+						number extends TypeOfField<Field, E, Index>
 							? number
 							: IsStringLiteral<TypeOfField<Field, E, Index>> extends true
 								? TypeOfField<Field, E, Index>
-								: string | number;
-						doc_count: number;
-					} & AppendSubAggs<BaseQuery, E, Index, Agg>
+								: string | number
+					> &
+						AppendSubAggs<BaseQuery, E, Index, Agg>
 				>;
 			},
 			Field

--- a/src/aggregations/bucket/variable_width_histogram.ts
+++ b/src/aggregations/bucket/variable_width_histogram.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { AtMostN, Prettify } from "../../types/helpers";
-import type { AggregationFieldTypeResult } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-variablewidthhistogram-aggregation
@@ -24,11 +24,9 @@ export type VariableWidthHistogram<
 			{
 				buckets: AtMostN<
 					Prettify<
-						{
+						KeyedBucketBase<number> & {
 							min: number;
-							key: number;
 							max: number;
-							doc_count: number;
 						} & AppendSubAggs<BaseQuery, E, Index, Agg>
 					>,
 					Buckets

--- a/src/aggregations/helpers.ts
+++ b/src/aggregations/helpers.ts
@@ -8,6 +8,20 @@ import type {
 } from "../lib";
 import type { IsSomeSortOf } from "../types/helpers";
 
+export type BucketBase = {
+	doc_count: number;
+};
+
+export type KeyedBucketBase<Key = string | number> = {
+	key: Key;
+	doc_count: number;
+};
+
+export type UnknownKeyedBucketBase<Key = string | number> =
+	KeyedBucketBase<Key> & {
+		[property: string]: unknown;
+	};
+
 export type AggregationPropertyTypeResult<
 	PropertyName extends string,
 	Aggregation,

--- a/src/aggregations/pipeline/change_point.ts
+++ b/src/aggregations/pipeline/change_point.ts
@@ -1,3 +1,4 @@
+import type { UnknownKeyedBucketBase } from "../helpers";
 import type { BucketsPath } from "./types";
 
 type ChangePointDetails = {
@@ -17,11 +18,7 @@ export type ChangePointType =
 			trend_change: { p_value: number; r_value: number; change_point: number };
 	  };
 
-export type ChangePointBucket = {
-	key: string | number;
-	doc_count: number;
-	[property: string]: unknown;
-};
+export type ChangePointBucket = UnknownKeyedBucketBase;
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation

--- a/src/aggregations/pipeline/change_point.ts
+++ b/src/aggregations/pipeline/change_point.ts
@@ -1,0 +1,83 @@
+import type {
+	AggregationOutput,
+	ElasticsearchIndexes,
+	ExtractAggs,
+	SearchRequest,
+} from "../../lib";
+import type { Prettify } from "../../types/helpers";
+import type { BucketsPath } from "./types";
+
+type ChangePointDetails = {
+	p_value: number;
+	change_point: number;
+};
+
+export type ChangePointType =
+	| { dip: ChangePointDetails }
+	| { distribution_change: ChangePointDetails }
+	| { indeterminable: { reason: string } }
+	| { non_stationary: { p_value: number; r_value: number; trend: string } }
+	| { spike: ChangePointDetails }
+	| { stationary: Record<never, never> }
+	| { step_change: ChangePointDetails }
+	| {
+			trend_change: { p_value: number; r_value: number; change_point: number };
+	  };
+
+type FirstBucketsPathSegment<Path> = Path extends `${infer Parent}>${string}`
+	? Parent
+	: Path;
+
+type ChangePointFallbackBucket = {
+	key: string | number;
+	doc_count: number;
+} & Record<string, unknown>;
+
+type ChangePointBucketFromAggregation<Aggregation> = Aggregation extends {
+	buckets: Array<infer Bucket>;
+}
+	? Prettify<{ key: string | number } & Omit<Bucket, "key" | "key_as_string">>
+	: Aggregation extends { buckets: Record<string, infer Bucket> }
+		? Prettify<{ key: string | number } & Omit<Bucket, "key" | "key_as_string">>
+		: ChangePointFallbackBucket;
+
+type ChangePointBucketFromPath<
+	BaseQuery extends SearchRequest,
+	Query extends Record<string, unknown>,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	BucketPath,
+> = BucketPath extends string
+	? FirstBucketsPathSegment<BucketPath> extends infer ParentAggregation extends
+			keyof ExtractAggs<Query>
+		? ChangePointBucketFromAggregation<
+				AggregationOutput<BaseQuery, Query, E, ParentAggregation, Index>
+			>
+		: ChangePointFallbackBucket
+	: ChangePointFallbackBucket;
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation
+ */
+export type ChangePoint<
+	BaseQuery extends SearchRequest,
+	Query extends Record<string, unknown>,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	change_point: {
+		buckets_path: infer BucketPath extends BucketsPath;
+	};
+}
+	? {
+			bucket?: ChangePointBucketFromPath<
+				BaseQuery,
+				Query,
+				E,
+				Index,
+				BucketPath
+			>;
+			type: ChangePointType;
+		}
+	: never;

--- a/src/aggregations/pipeline/change_point.ts
+++ b/src/aggregations/pipeline/change_point.ts
@@ -1,10 +1,3 @@
-import type {
-	AggregationOutput,
-	ElasticsearchIndexes,
-	ExtractAggs,
-	SearchRequest,
-} from "../../lib";
-import type { Prettify } from "../../types/helpers";
 import type { BucketsPath } from "./types";
 
 type ChangePointDetails = {
@@ -24,60 +17,22 @@ export type ChangePointType =
 			trend_change: { p_value: number; r_value: number; change_point: number };
 	  };
 
-type FirstBucketsPathSegment<Path> = Path extends `${infer Parent}>${string}`
-	? Parent
-	: Path;
-
-type ChangePointFallbackBucket = {
+export type ChangePointBucket = {
 	key: string | number;
 	doc_count: number;
-} & Record<string, unknown>;
-
-type ChangePointBucketFromAggregation<Aggregation> = Aggregation extends {
-	buckets: Array<infer Bucket>;
-}
-	? Prettify<{ key: string | number } & Omit<Bucket, "key" | "key_as_string">>
-	: Aggregation extends { buckets: Record<string, infer Bucket> }
-		? Prettify<{ key: string | number } & Omit<Bucket, "key" | "key_as_string">>
-		: ChangePointFallbackBucket;
-
-type ChangePointBucketFromPath<
-	BaseQuery extends SearchRequest,
-	Query extends Record<string, unknown>,
-	E extends ElasticsearchIndexes,
-	Index extends string,
-	BucketPath,
-> = BucketPath extends string
-	? FirstBucketsPathSegment<BucketPath> extends infer ParentAggregation extends
-			keyof ExtractAggs<Query>
-		? ChangePointBucketFromAggregation<
-				AggregationOutput<BaseQuery, Query, E, ParentAggregation, Index>
-			>
-		: ChangePointFallbackBucket
-	: ChangePointFallbackBucket;
+	[property: string]: unknown;
+};
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-change-point-aggregation
  */
-export type ChangePoint<
-	BaseQuery extends SearchRequest,
-	Query extends Record<string, unknown>,
-	E extends ElasticsearchIndexes,
-	Index extends string,
-	Agg,
-> = Agg extends {
+export type ChangePoint<_BaseQuery, _Query, _E, _Index, Agg> = Agg extends {
 	change_point: {
-		buckets_path: infer BucketPath extends BucketsPath;
+		buckets_path: BucketsPath;
 	};
 }
 	? {
-			bucket?: ChangePointBucketFromPath<
-				BaseQuery,
-				Query,
-				E,
-				Index,
-				BucketPath
-			>;
+			bucket?: ChangePointBucket;
 			type: ChangePointType;
 		}
 	: never;

--- a/src/aggregations/pipeline/index.ts
+++ b/src/aggregations/pipeline/index.ts
@@ -2,6 +2,7 @@ export * from "./avg_bucket";
 export * from "./bucket_correlation";
 export * from "./bucket_count_ks_test";
 export * from "./bucket_script";
+export * from "./change_point";
 export * from "./cumulative_cardinality";
 export * from "./cumulative_sum";
 export * from "./derivative";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -313,6 +313,7 @@ export type NextAggsParentKey<
 	| "bucket_correlation"
 	| "bucket_count_ks_test"
 	| "bucket_script"
+	| "change_point"
 	| "cumulative_cardinality"
 	| "cumulative_sum"
 	| "derivative"
@@ -397,6 +398,7 @@ export type AggregationOutput<
 				| Pipeline.BucketCorrelation<Agg>
 				| Pipeline.BucketCountKSTest<Agg>
 				| Pipeline.BucketScript<Agg>
+				| Pipeline.ChangePoint<BaseQuery, Query, E, Index, Agg>
 				| Pipeline.CumulativeCardinality<Agg>
 				| Pipeline.CumulativeSum<Agg>
 				| Pipeline.Derivative<Agg>

--- a/tests/aggregations/pipeline/change_point.test.ts
+++ b/tests/aggregations/pipeline/change_point.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { ChangePointType } from "../../../src/aggregations/pipeline";
+import type {
+	ChangePointBucket,
+	ChangePointType,
+} from "../../../src/aggregations/pipeline";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Change Point Pipeline Aggregation", () => {
@@ -25,11 +28,7 @@ describe("Change Point Pipeline Aggregation", () => {
 				}>;
 			};
 			change_points_avg: {
-				bucket?: {
-					key: string | number;
-					doc_count: number;
-					avg: { value: number; value_as_string?: string };
-				};
+				bucket?: ChangePointBucket;
 				type: ChangePointType;
 			};
 		}>();

--- a/tests/aggregations/pipeline/change_point.test.ts
+++ b/tests/aggregations/pipeline/change_point.test.ts
@@ -1,6 +1,5 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
+import type { ChangePointType } from "../../../src/aggregations/pipeline";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Change Point Pipeline Aggregation", () => {
@@ -31,7 +30,7 @@ describe("Change Point Pipeline Aggregation", () => {
 					doc_count: number;
 					avg: { value: number; value_as_string?: string };
 				};
-				type: Record<string, unknown>;
+				type: ChangePointType;
 			};
 		}>();
 	});


### PR DESCRIPTION
## Summary
- add typed support for the `change_point` pipeline aggregation
- infer the reported `bucket` shape from the referenced sibling multi-bucket aggregation when `buckets_path` is a literal path
- update the docs table and add a patch changeset

## Notes
- The `type` response is modeled as the possible Elasticsearch change point variants.
- The docs example is covered in `tests/aggregations/pipeline/change_point.test.ts`.

Closes #245
