### PR TITLE
feat: add time series aggregation support

### DIFF
--- a/.changeset/time-series-aggregation.md
+++ b/.changeset/time-series-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add type support for the `time_series` bucket aggregation.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm install -D @vahor/typed-es
 | Significant Terms | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significantterms-aggregation) |
 | Significant Text | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-significanttext-aggregation) |
 | Terms | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-terms-aggregation) |
-| Time Series | ❌ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-time-series-aggregation) |
+| Time Series | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-time-series-aggregation) |
 | Variable Width Histogram | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-variablewidthhistogram-aggregation) |
 
 ### Metrics Aggregations

--- a/src/aggregations/bucket/index.ts
+++ b/src/aggregations/bucket/index.ts
@@ -28,4 +28,5 @@ export * from "./sampler";
 export * from "./significant_terms";
 export * from "./significant_text";
 export * from "./terms";
+export * from "./time_series";
 export * from "./variable_width_histogram";

--- a/src/aggregations/bucket/time_series.ts
+++ b/src/aggregations/bucket/time_series.ts
@@ -1,0 +1,42 @@
+import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
+import type { Prettify, PrettyArray } from "../../types/helpers";
+import type { BucketBase } from "../helpers";
+
+type TimeSeriesKeyValue = string | number | boolean | null;
+
+export type TimeSeriesKey = Record<string, TimeSeriesKeyValue>;
+
+type TimeSeriesBucket<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg extends Record<string, unknown>,
+> = Prettify<
+	BucketBase & {
+		key: TimeSeriesKey;
+	} & AppendSubAggs<BaseQuery, E, Index, Agg>
+>;
+
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-time-series-aggregation
+ */
+export type TimeSeries<
+	BaseQuery extends SearchRequest,
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+> = Agg extends {
+	time_series: {
+		keyed?: infer Keyed;
+	};
+}
+	? Agg extends Record<string, unknown>
+		? Keyed extends true
+			? {
+					buckets: Record<string, TimeSeriesBucket<BaseQuery, E, Index, Agg>>;
+				}
+			: {
+					buckets: PrettyArray<TimeSeriesBucket<BaseQuery, E, Index, Agg>>;
+				}
+		: never
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -301,6 +301,7 @@ export type NextAggsParentKey<
 	| "t_test"
 	| "multi_terms"
 	| "terms"
+	| "time_series"
 	| "rare_terms"
 	| "top_hits"
 	| "top_metrics"
@@ -368,6 +369,7 @@ export type AggregationOutput<
 				| Bucket.SignificantText<BaseQuery, E, Index, Agg>
 				| Bucket.SignificantTerms<BaseQuery, E, Index, Agg>
 				| Bucket.Terms<BaseQuery, E, Index, Agg>
+				| Bucket.TimeSeries<BaseQuery, E, Index, Agg>
 				| Bucket.RareTerms<BaseQuery, E, Index, Agg>
 				| Bucket.MultiTerms<BaseQuery, E, Index, Agg>
 				| Bucket.VariableWidthHistogram<BaseQuery, E, Index, Agg>

--- a/tests/aggregations/bucket/time_series.test.ts
+++ b/tests/aggregations/bucket/time_series.test.ts
@@ -1,6 +1,5 @@
-// @ts-nocheck
-// TODO implement aggregation
 import { describe, expectTypeOf, test } from "bun:test";
+import type { TimeSeriesKey } from "../../../src/aggregations/bucket/time_series";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Time Series Bucket Aggregation", () => {
@@ -13,11 +12,16 @@ describe("Time Series Bucket Aggregation", () => {
 		>;
 
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
-			ts: { buckets: Array<{ key: string | number; doc_count: number }> };
+			ts: {
+				buckets: Array<{
+					key: TimeSeriesKey;
+					doc_count: number;
+				}>;
+			};
 		}>();
 	});
 
-	test("docs example: keyed=true", () => {
+	test("with keyed=true", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",
 			{
@@ -26,7 +30,39 @@ describe("Time Series Bucket Aggregation", () => {
 		>;
 
 		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
-			ts: { buckets: Record<string, { doc_count: number }> };
+			ts: {
+				buckets: Record<
+					string,
+					{
+						key: TimeSeriesKey;
+						doc_count: number;
+					}
+				>;
+			};
+		}>();
+	});
+
+	test("with nested aggregations", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				ts: {
+					time_series: { keyed: false };
+					aggs: {
+						max_price: { max: { field: "price" } };
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			ts: {
+				buckets: Array<{
+					key: TimeSeriesKey;
+					doc_count: number;
+					max_price: { value: number; value_as_string?: string };
+				}>;
+			};
 		}>();
 	});
 });


### PR DESCRIPTION
## Summary
- add output typing for the `time_series` bucket aggregation
- support array and keyed bucket responses, including nested aggregations
- mark `time_series` as supported in the README and add a patch changeset

## Notes
- Bucket keys follow the Elasticsearch response shape of a dimension-value object.

Closes #232