### PR TITLE
Add moving average aggregation types

### DIFF
--- a/.changeset/moving-average-aggregation.md
+++ b/.changeset/moving-average-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add output type support for the `moving_avg` pipeline aggregation.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ npm install -D @vahor/typed-es
 | Inference | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-inference-bucket-aggregation) |
 | Max Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-max-bucket-aggregation) |
 | Min Bucket | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-min-bucket-aggregation) |
+| Moving Average | ✅ | [docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-aggregations-pipeline-movavg-aggregation.html) |
 | Moving Function | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-movfn-aggregation) |
 | Moving Percentiles | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-moving-percentiles-aggregation) |
 | Normalize | ✅ | [docs](https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-normalize-aggregation) |

--- a/src/aggregations/pipeline/index.ts
+++ b/src/aggregations/pipeline/index.ts
@@ -10,6 +10,7 @@ export * from "./extended_stats_bucket";
 export * from "./inference";
 export * from "./max_bucket";
 export * from "./min_bucket";
+export * from "./moving_avg";
 export * from "./moving_fn";
 export * from "./moving_percentiles";
 export * from "./normalize";

--- a/src/aggregations/pipeline/moving_avg.ts
+++ b/src/aggregations/pipeline/moving_avg.ts
@@ -1,6 +1,7 @@
 import type { BucketsPath } from "./types";
 
 /**
+ * @deprecated Use `moving_fn` instead.
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-aggregations-pipeline-movavg-aggregation.html
  */
 export type MovingAverage<Agg> = Agg extends {

--- a/src/aggregations/pipeline/moving_avg.ts
+++ b/src/aggregations/pipeline/moving_avg.ts
@@ -1,0 +1,13 @@
+import type { BucketsPath } from "./types";
+
+/**
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-aggregations-pipeline-movavg-aggregation.html
+ */
+export type MovingAverage<Agg> = Agg extends {
+	moving_avg: { buckets_path: BucketsPath };
+}
+	? {
+			value: number;
+			value_as_string?: string;
+		}
+	: never;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -324,6 +324,7 @@ export type NextAggsParentKey<
 	| "max_bucket"
 	| "extended_stats_bucket"
 	| "inference"
+	| "moving_avg"
 	| "moving_fn"
 	| "normalize"
 	| "percentiles_bucket"
@@ -408,6 +409,7 @@ export type AggregationOutput<
 				| Pipeline.Inference<Agg>
 				| Pipeline.MaxBucket<Agg>
 				| Pipeline.MinBucket<Agg>
+				| Pipeline.MovingAverage<Agg>
 				| Pipeline.MovingFunction<Agg>
 				| Pipeline.MovingPercentiles<ExtractAggs<Query>, E, Index, Agg>
 				| Pipeline.Normalize<Agg>
@@ -604,10 +606,49 @@ export type OverwrittenSearchRequestFields =
 	| "sort"
 	| "query";
 
-export type SearchRequest = Pick<
-	estypes.SearchRequest,
-	Exclude<OverwrittenSearchRequestFields, IssueWithReadonlyArray>
->;
+type AggregationBucketsPath = string | string[] | Record<string, string>;
+
+type MovingAverageAggregationModel =
+	| "simple"
+	| "linear"
+	| "ewma"
+	| "holt"
+	| "holt_winters";
+
+type LooseMovingAverageAggregation = {
+	buckets_path?: AggregationBucketsPath;
+	model?: MovingAverageAggregationModel;
+	gap_policy?: string;
+	format?: string;
+	minimize?: boolean;
+	predict?: number;
+	window?: number;
+	settings?: Record<string, unknown>;
+};
+
+type TypedAggregationContainer = {
+	[K in keyof estypes.AggregationsAggregationContainer as K extends
+		| "aggs"
+		| "aggregations"
+		| "moving_avg"
+		? never
+		: K]?: estypes.AggregationsAggregationContainer[K];
+} & {
+	aggregations?: Record<string, TypedAggregationContainer>;
+	aggs?: Record<string, TypedAggregationContainer>;
+	moving_avg?: LooseMovingAverageAggregation;
+};
+
+export type SearchRequest = Omit<
+	Pick<
+		estypes.SearchRequest,
+		Exclude<OverwrittenSearchRequestFields, IssueWithReadonlyArray>
+	>,
+	"aggs" | "aggregations"
+> & {
+	aggs?: Record<string, TypedAggregationContainer>;
+	aggregations?: Record<string, TypedAggregationContainer>;
+};
 
 /**
  * HACK: const Query modifier cause sort/query to be readonly. which cause issues with estypes versions as it has mutable arrays in types.
@@ -685,9 +726,17 @@ type TypedSearchRequestForIndex<
 
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 	estypes.SearchRequest,
-	"index" | "_source" | "fields" | "docvalue_fields" | IssueWithReadonlyArray
-> &
-	(
+	| "index"
+	| "_source"
+	| "fields"
+	| "docvalue_fields"
+	| "aggs"
+	| "aggregations"
+	| IssueWithReadonlyArray
+> & {
+	aggs?: Record<string, TypedAggregationContainer>;
+	aggregations?: Record<string, TypedAggregationContainer>;
+} & (
 		| {
 				[K in Extract<keyof Indexes, string>]: TypedSearchRequestForIndex<
 					Indexes,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -615,6 +615,10 @@ type MovingAverageAggregationModel =
 	| "holt"
 	| "holt_winters";
 
+/**
+ * @deprecated Use `moving_fn` instead.
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-movfn-aggregation
+ */
 type LooseMovingAverageAggregation = {
 	buckets_path?: AggregationBucketsPath;
 	model?: MovingAverageAggregationModel;
@@ -636,6 +640,9 @@ type TypedAggregationContainer = {
 } & {
 	aggregations?: Record<string, TypedAggregationContainer>;
 	aggs?: Record<string, TypedAggregationContainer>;
+	/**
+	 * @deprecated Use `moving_fn` instead.
+	 */
 	moving_avg?: LooseMovingAverageAggregation;
 };
 

--- a/tests/aggregations/pipeline/moving_avg.test.ts
+++ b/tests/aggregations/pipeline/moving_avg.test.ts
@@ -1,0 +1,68 @@
+import { describe, expectTypeOf, test } from "bun:test";
+import type { TestAggregationOutput } from "../../shared";
+
+describe("Moving Average Pipeline Aggregation", () => {
+	test("docs example: moving average of monthly sales", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				my_date_histo: {
+					date_histogram: { field: "date"; calendar_interval: "1M" };
+					aggs: {
+						the_sum: { sum: { field: "price" } };
+						the_movavg: {
+							moving_avg: { buckets_path: "the_sum" };
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			my_date_histo: {
+				buckets: Array<{
+					key_as_string: string;
+					key: number;
+					doc_count: number;
+					the_sum: { value: number; value_as_string?: string };
+					the_movavg: { value: number; value_as_string?: string };
+				}>;
+			};
+		}>();
+	});
+
+	test("supports model settings", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				my_date_histo: {
+					date_histogram: { field: "date"; calendar_interval: "1M" };
+					aggs: {
+						the_sum: { sum: { field: "price" } };
+						the_movavg: {
+							moving_avg: {
+								buckets_path: "the_sum";
+								model: "holt";
+								window: 5;
+								gap_policy: "insert_zeros";
+								settings: { alpha: 0.8 };
+							};
+						};
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			my_date_histo: {
+				buckets: Array<{
+					key_as_string: string;
+					key: number;
+					doc_count: number;
+					the_sum: { value: number; value_as_string?: string };
+					the_movavg: { value: number; value_as_string?: string };
+				}>;
+			};
+		}>();
+	});
+});


### PR DESCRIPTION
## Summary
- add `moving_avg` pipeline aggregation output typing
- allow the deprecated docs example shape in typed search aggregation inputs
- add moving average aggregation tests, README table entry, and a patch changeset

## Notes
- `moving_avg` is deprecated upstream in favor of `moving_fn`, but the issue tracks adding the legacy aggregation.

Closes #275