### PR TITLE
fix: add type test coverage check

### DIFF
--- a/.changeset/type-coverage-check.md
+++ b/.changeset/type-coverage-check.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add a type test coverage check, README badge, and CI validation.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,6 +27,18 @@ jobs:
       - name: Run Biome
         run: biome ci .
 
+  type-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2.2.0
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run type coverage
+        run: bun run type-coverage
+
   typecheck:
     runs-on: ubuntu-latest
     name: typecheck (${{ matrix.elasticsearch-version }}, ${{ matrix.typescript }})

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Typed ES — type-safe Elasticsearch responses for TypeScript
 
 [![Code quality](https://github.com/vahor/typed-es/actions/workflows/quality.yml/badge.svg)](https://github.com/vahor/typed-es/actions/workflows/quality.yml)
+[![type test coverage](https://img.shields.io/badge/dynamic/json?label=type%20test%20coverage&query=%24.typeCoverage.atLeast&suffix=%25&prefix=%E2%89%A5&url=https%3A%2F%2Fraw.githubusercontent.com%2FVahor%2Ftyped-es%2Fmain%2Fpackage.json)](https://github.com/Vahor/typed-es/actions/workflows/quality.yml)
 [![npm version](https://img.shields.io/npm/v/%40vahor%2Ftyped-es)](https://www.npmjs.com/package/@vahor/typed-es)
 [![npm downloads](https://img.shields.io/npm/dm/%40vahor%2Ftyped-es)](https://www.npmjs.com/package/@vahor/typed-es)
 [![license](https://img.shields.io/npm/l/%40vahor%2Ftyped-es)](https://github.com/Vahor/typed-es/blob/main/LICENSE)

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
 		"@changesets/changelog-github": "^0.7.0",
 		"@changesets/cli": "^2.31.0",
 		"@types/bun": "^1.3.13",
-		"tsdown": "^0.22.0",
 		"husky": "^9.1.7",
 		"lint-staged": "^17.0.3",
 		"pkg-pr-new": "^0.0.71",
+		"tsdown": "^0.22.0",
 		"typescript": "^6.0.3"
 	},
 	"peerDependencies": {
@@ -72,8 +72,23 @@
 		"build": "bunx tsdown",
 		"format": "bunx @biomejs/biome check ./ --write",
 		"typecheck": "tsc --noEmit --declaration",
+		"type-coverage": "bun scripts/check-type-coverage.ts",
 		"ci:version": "bunx @changesets/cli version",
 		"ci:publish": "bun run build && bun publish && bunx changeset tag"
+	},
+	"typeCoverage": {
+		"atLeast": 100,
+		"ignoredSourceFiles": [
+			"src/index.ts",
+			"src/lib.ts",
+			"src/types/fields.ts",
+			"src/types/helpers.ts",
+			"src/aggregations/helpers.ts",
+			"src/aggregations/bucket/index.ts",
+			"src/aggregations/metrics/index.ts",
+			"src/aggregations/pipeline/index.ts",
+			"src/aggregations/pipeline/types.ts"
+		]
 	},
 	"lint-staged": {
 		"*": [

--- a/scripts/check-type-coverage.ts
+++ b/scripts/check-type-coverage.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+type PackageJson = {
+	typeCoverage?: {
+		atLeast?: number;
+		ignoredSourceFiles?: string[];
+	};
+};
+
+type CoverageResult = {
+	sourceFile: string;
+	testFiles: string[];
+	typeAssertionCount: number;
+};
+
+const typeAssertionPattern = /\bexpectTypeOf\s*(?:<|\()/gu;
+const packageJson = JSON.parse(
+	readFileSync("package.json", "utf8"),
+) as PackageJson;
+const atLeast = packageJson.typeCoverage?.atLeast ?? 100;
+const ignoredSourceFiles = new Set(
+	packageJson.typeCoverage?.ignoredSourceFiles ?? [],
+);
+
+function walk(directory: string): string[] {
+	return readdirSync(directory).flatMap((entry) => {
+		const path = join(directory, entry);
+		const stats = statSync(path);
+
+		return stats.isDirectory() ? walk(path) : [toPosixPath(path)];
+	});
+}
+
+function toPosixPath(path: string): string {
+	return path.replaceAll("\\", "/");
+}
+
+function normalizedStem(path: string): string {
+	return basename(path)
+		.replace(/\.test\.ts$|\.ts$/u, "")
+		.replaceAll("_", "-");
+}
+
+function countTypeAssertions(path: string): number {
+	return readFileSync(path, "utf8").match(typeAssertionPattern)?.length ?? 0;
+}
+
+const testFiles = walk("tests").filter((path) => path.endsWith(".test.ts"));
+const testsByStem = Map.groupBy(testFiles, normalizedStem);
+
+const results: CoverageResult[] = walk("src")
+	.filter((path) => path.endsWith(".ts"))
+	.filter((path) => !ignoredSourceFiles.has(path))
+	.map((sourceFile) => {
+		const matchingTestFiles = testsByStem.get(normalizedStem(sourceFile)) ?? [];
+
+		return {
+			sourceFile,
+			testFiles: matchingTestFiles,
+			typeAssertionCount: matchingTestFiles.reduce(
+				(count, testFile) => count + countTypeAssertions(testFile),
+				0,
+			),
+		};
+	});
+
+const coveredResults = results.filter(
+	(result) => result.typeAssertionCount > 0,
+);
+const uncoveredResults = results.filter(
+	(result) => result.typeAssertionCount === 0,
+);
+const percentage =
+	results.length === 0 ? 100 : (coveredResults.length / results.length) * 100;
+
+console.log(
+	`Type test coverage: ${coveredResults.length}/${results.length} (${percentage.toFixed(2)}%)`,
+);
+
+if (uncoveredResults.length > 0) {
+	console.log("\nMissing type assertions:");
+	for (const result of uncoveredResults) {
+		const testFiles =
+			result.testFiles.length === 0
+				? "no matching test file"
+				: result.testFiles.join(", ");
+		console.log(`- ${result.sourceFile} (${testFiles})`);
+	}
+}
+
+if (percentage < atLeast) {
+	console.error(
+		`\nType test coverage ${percentage.toFixed(2)}% is below the required ${atLeast}%.`,
+	);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a `bun run type-coverage` check that maps source type modules to matching type test files with `expectTypeOf` assertions
- run the coverage check in CI and expose the required threshold in a README badge
- add a patch changeset

## Notes
- This does not only check that a test file exists: the matching test must contain type assertions. Temporarily removing `expectTypeOf` from `tests/typed-es.test.ts` drops coverage to 98.75% and reports `src/typed-es.ts` as missing assertions.
- Barrel/helper type files that are covered indirectly are listed in `typeCoverage.ignoredSourceFiles`.

Closes #98