### PR TITLE
fix: restrict stats aggregation to numeric fields

### DIFF
--- a/.changeset/limit-stats-field-type.md
+++ b/.changeset/limit-stats-field-type.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Restrict the `stats` aggregation to numeric fields.

--- a/src/aggregations/metrics/stats.ts
+++ b/src/aggregations/metrics/stats.ts
@@ -1,5 +1,5 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-stats-aggregation
@@ -13,10 +13,11 @@ export type Stats<
 		field: infer Field extends string;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			number,
 			{
 				count: number;
 				min: number;

--- a/tests/aggregations/metrics/stats.test.ts
+++ b/tests/aggregations/metrics/stats.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Stats Aggregation", () => {
@@ -26,6 +29,28 @@ describe("Stats Aggregation", () => {
 				sum: number;
 				sum_as_string?: string;
 			};
+		}>();
+	});
+
+	test("fails when using a non-numeric field", () => {
+		type Aggregations = TestAggregationOutput<
+			"orders",
+			{
+				status_stats: {
+					stats: {
+						field: "status";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			status_stats: InvalidFieldTypeInAggregation<
+				"status",
+				"orders",
+				Aggregations["input"]["status_stats"],
+				"pending" | "completed" | "cancelled",
+				number
+			>;
 		}>();
 	});
 


### PR DESCRIPTION
## Summary
- restrict the `stats` aggregation to numeric fields
- add a type test for rejecting non-numeric `stats` fields
- add a patch changeset

## Notes
- This fixes the explicit `stats` example from #104 without broadening the scope to every aggregation type.

Refs #104