### PR TITLE
fix: validate sum and avg field types

### DIFF
--- a/.changeset/limit-basic-metric-functions.md
+++ b/.changeset/limit-basic-metric-functions.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Validate `sum` and `avg` metric aggregation fields as numeric fields.

--- a/src/aggregations/metrics/function.ts
+++ b/src/aggregations/metrics/function.ts
@@ -1,5 +1,8 @@
 import type { ElasticsearchIndexes, TypeOfField } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type {
+	AggregationFieldResult,
+	AggregationFieldTypeResult,
+} from "../helpers";
 
 type ExtractAggField<Agg> = {
 	[Fn in Extract<keyof Agg, AggFunction>]: Agg[Fn] extends {
@@ -9,27 +12,58 @@ type ExtractAggField<Agg> = {
 		: never;
 }[Extract<keyof Agg, AggFunction>];
 
-type AggFunctionsNumber = "value_count" | "cardinality";
+type AggFunctionsCount = "value_count" | "cardinality";
+type AggFunctionsNumericField = "sum" | "avg";
+type AggFunctionsNumericOrDateField = "max" | "min";
 
-export type AggFunction = AggFunctionsNumber | "sum" | "avg" | "max" | "min";
+export type AggFunction =
+	| AggFunctionsCount
+	| AggFunctionsNumericField
+	| AggFunctionsNumericOrDateField;
+
+type NumericFunctionResult = {
+	value_as_string?: string;
+	value: number;
+};
+
+type FunctionOutput<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Agg,
+	Fn extends AggFunction,
+	Field extends string,
+> = Fn extends AggFunctionsNumericField
+	? AggregationFieldTypeResult<
+			E,
+			Index,
+			Agg,
+			number,
+			NumericFunctionResult,
+			Field
+		>
+	: AggregationFieldResult<
+			E,
+			Index,
+			Agg,
+			{
+				value_as_string?: string;
+				value: Fn extends AggFunctionsCount
+					? number
+					: TypeOfField<Field, E, Index> extends number
+						? number
+						: number | string;
+			},
+			Field
+		>;
 
 export type Function<
 	E extends ElasticsearchIndexes,
 	Index extends string,
 	Agg,
 	FieldAgg = ExtractAggField<Agg>,
-> = FieldAgg extends { fn: string; field: string }
-	? AggregationFieldResult<
-			E,
-			Index,
-			Agg,
-			{
-				value_as_string?: string;
-				value: FieldAgg["fn"] extends AggFunctionsNumber
-					? number
-					: TypeOfField<FieldAgg["field"], E, Index> extends number
-						? number
-						: number | string;
-			}
-		>
+> = FieldAgg extends {
+	fn: infer Fn extends AggFunction;
+	field: infer Field extends string;
+}
+	? FunctionOutput<E, Index, Agg, Fn, Field>
 	: never;

--- a/tests/aggregations/metrics/function.test.ts
+++ b/tests/aggregations/metrics/function.test.ts
@@ -1,5 +1,9 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import { type InvalidFieldInAggregation, typedEs } from "../../../src/index";
+import {
+	type InvalidFieldInAggregation,
+	type InvalidFieldTypeInAggregation,
+	typedEs,
+} from "../../../src/index";
 import type { TypedSearchResponse } from "../../../src/override/search-response";
 import {
 	type CustomIndexes,
@@ -187,6 +191,11 @@ describe("Leaf Function Aggregations", () => {
 					};
 				};
 				//
+				str_avg: {
+					avg: {
+						field: "name";
+					};
+				};
 				num_avg: {
 					avg: {
 						field: "price";
@@ -198,6 +207,11 @@ describe("Leaf Function Aggregations", () => {
 					};
 				};
 				//
+				str_sum: {
+					sum: {
+						field: "name";
+					};
+				};
 				num_sum: {
 					sum: {
 						field: "price";
@@ -267,22 +281,42 @@ describe("Leaf Function Aggregations", () => {
 				value: number | string;
 				value_as_string?: string;
 			};
+			str_avg: InvalidFieldTypeInAggregation<
+				"name",
+				"test_types",
+				Aggregations["input"]["str_avg"],
+				string,
+				number
+			>;
 			num_avg: {
 				value: number;
 				value_as_string?: string;
 			};
-			date_avg: {
-				value: number | string;
-				value_as_string?: string;
-			};
+			date_avg: InvalidFieldTypeInAggregation<
+				"timestamp",
+				"test_types",
+				Aggregations["input"]["date_avg"],
+				Date,
+				number
+			>;
+			str_sum: InvalidFieldTypeInAggregation<
+				"name",
+				"test_types",
+				Aggregations["input"]["str_sum"],
+				string,
+				number
+			>;
 			num_sum: {
 				value: number;
 				value_as_string?: string;
 			};
-			date_sum: {
-				value: number | string;
-				value_as_string?: string;
-			};
+			date_sum: InvalidFieldTypeInAggregation<
+				"timestamp",
+				"test_types",
+				Aggregations["input"]["date_sum"],
+				Date,
+				number
+			>;
 			str_value_count: {
 				value: number;
 				value_as_string?: string;


### PR DESCRIPTION
## Summary
- validate `sum` and `avg` metric aggregation fields as numeric fields
- add type tests for string and date-like invalid `sum`/`avg` fields
- add a patch changeset

## Notes
- `min`/`max`, `value_count`, and `cardinality` behavior is left unchanged because this PR focuses on the missing numeric-only validation for `sum`/`avg`.

Refs #104