### PR TITLE
fix: validate aggregation field types

### DIFF
--- a/.changeset/limit-aggregation-field-types.md
+++ b/.changeset/limit-aggregation-field-types.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add field-type validation to `extended_stats`, `histogram`, `range`, `auto_date_histogram`, `date_histogram`, and `date_range`, so incompatible fields now return `InvalidFieldTypeInAggregation`.

--- a/src/aggregations/bucket/auto_date_histogram.ts
+++ b/src/aggregations/bucket/auto_date_histogram.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { PrettyArray } from "../../types/helpers";
-import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-autodatehistogram-aggregation
@@ -15,10 +15,11 @@ export type AutoDateHistogram<
 		field: infer Field extends string;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			string,
 			{
 				buckets: PrettyArray<
 					KeyedBucketBase<number> & {

--- a/src/aggregations/bucket/date_histogram.ts
+++ b/src/aggregations/bucket/date_histogram.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { Prettify, PrettyArray } from "../../types/helpers";
-import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation
@@ -16,10 +16,11 @@ export type DateHistogram<
 		keyed?: infer Keyed;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			string,
 			Keyed extends true
 				? {
 						buckets: Record<

--- a/src/aggregations/bucket/date_range.ts
+++ b/src/aggregations/bucket/date_range.ts
@@ -1,6 +1,6 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
 import type { KeyedArrayToObject, Prettify } from "../../types/helpers";
-import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 type RangeSpec = {
 	from?: string | undefined;
@@ -55,10 +55,11 @@ export type DateRange<
 		ranges: infer Ranges;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			string,
 			Ranges extends readonly RangeSpec[]
 				? Keyed extends true
 					? {

--- a/src/aggregations/bucket/histogram.ts
+++ b/src/aggregations/bucket/histogram.ts
@@ -1,5 +1,5 @@
 import type { AppendSubAggs, ElasticsearchIndexes, SearchRequest } from "../..";
-import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 type HistogramAggOutput<
 	BaseQuery extends SearchRequest,
@@ -23,10 +23,11 @@ export type Histogram<
 		keyed?: infer Keyed;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			number,
 			Keyed extends true
 				? {
 						buckets: Record<

--- a/src/aggregations/bucket/range.ts
+++ b/src/aggregations/bucket/range.ts
@@ -6,7 +6,7 @@ import type {
 	ToDecimal,
 	ToString,
 } from "../../types/helpers";
-import type { AggregationFieldResult, KeyedBucketBase } from "../helpers";
+import type { AggregationFieldTypeResult, KeyedBucketBase } from "../helpers";
 
 type RangeSpec = {
 	from?: number | undefined;
@@ -59,10 +59,11 @@ export type Range<
 		ranges: infer Ranges;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			number,
 			Ranges extends readonly RangeSpec[]
 				? Keyed extends true
 					? {

--- a/src/aggregations/metrics/extended_stats.ts
+++ b/src/aggregations/metrics/extended_stats.ts
@@ -1,5 +1,5 @@
 import type { ElasticsearchIndexes } from "../..";
-import type { AggregationFieldResult } from "../helpers";
+import type { AggregationFieldTypeResult } from "../helpers";
 
 /**
  * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-metrics-extendedstats-aggregation
@@ -13,10 +13,11 @@ export type ExtendedStats<
 		field: infer Field extends string;
 	};
 }
-	? AggregationFieldResult<
+	? AggregationFieldTypeResult<
 			E,
 			Index,
 			Agg,
+			number,
 			{
 				count: number;
 				min: number;

--- a/tests/aggregations/bucket/auto_date_histogram.test.ts
+++ b/tests/aggregations/bucket/auto_date_histogram.test.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, test } from "bun:test";
+import type { InvalidFieldTypeInAggregation } from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Auto Date Histogram Aggregations", () => {
@@ -24,6 +25,30 @@ describe("Auto Date Histogram Aggregations", () => {
 				}>;
 				interval: string;
 			};
+		}>();
+	});
+
+	test("fails when using a non-date field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				sales_over_time: {
+					auto_date_histogram: {
+						field: "score";
+						buckets: 10;
+					};
+				};
+			}
+		>;
+
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			sales_over_time: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["sales_over_time"],
+				number,
+				string
+			>;
 		}>();
 	});
 

--- a/tests/aggregations/bucket/date_histogram.test.ts
+++ b/tests/aggregations/bucket/date_histogram.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Date Histogram Aggregations", () => {
@@ -84,6 +87,30 @@ describe("Date Histogram Aggregations", () => {
 					}
 				>;
 			};
+		}>();
+	});
+
+	test("fails when using a non-date field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				sales_over_time: {
+					date_histogram: {
+						field: "score";
+						calendar_interval: "1M";
+						format: "yyyy-MM-dd";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			sales_over_time: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["sales_over_time"],
+				number,
+				string
+			>;
 		}>();
 	});
 

--- a/tests/aggregations/bucket/date_range.test.ts
+++ b/tests/aggregations/bucket/date_range.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("DateRange Aggregations", () => {
@@ -122,6 +125,31 @@ describe("DateRange Aggregations", () => {
 					};
 				};
 			};
+		}>();
+	});
+
+	test("fails when using a non-date field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				range: {
+					date_range: {
+						field: "score";
+						format: "MM-yyy";
+						ranges: [{ from: "01-2015"; to: "03-2015"; key: "quarter_01" }];
+						keyed: true;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			range: InvalidFieldTypeInAggregation<
+				"score",
+				"demo",
+				Aggregations["input"]["range"],
+				number,
+				string
+			>;
 		}>();
 	});
 

--- a/tests/aggregations/bucket/histogram.test.ts
+++ b/tests/aggregations/bucket/histogram.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Histogram Aggregations", () => {
@@ -48,6 +51,29 @@ describe("Histogram Aggregations", () => {
 					}
 				>;
 			};
+		}>();
+	});
+
+	test("fails when using a non-numeric field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				prices: {
+					histogram: {
+						field: "entity_id";
+						interval: 50;
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			prices: InvalidFieldTypeInAggregation<
+				"entity_id",
+				"demo",
+				Aggregations["input"]["prices"],
+				string,
+				number
+			>;
 		}>();
 	});
 

--- a/tests/aggregations/bucket/range.test.ts
+++ b/tests/aggregations/bucket/range.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Range Aggregations", () => {
@@ -164,6 +167,30 @@ describe("Range Aggregations", () => {
 		}>();
 	});
 
+	test("fails when using a non-numeric field", () => {
+		type Aggregations = TestAggregationOutput<
+			"demo",
+			{
+				price_ranges: {
+					range: {
+						field: "entity_id";
+						keyed: true;
+						ranges: [{ to: 100 }, { from: 100; to: 200 }, { from: 200 }];
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_ranges: InvalidFieldTypeInAggregation<
+				"entity_id",
+				"demo",
+				Aggregations["input"]["price_ranges"],
+				string,
+				number
+			>;
+		}>();
+	});
+
 	test("fails when using an invalid field", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",
@@ -191,7 +218,7 @@ describe("Range Aggregations", () => {
 			"orders",
 			{
 				with_sub: {
-					range: { field: "shipping_address.geo_point"; ranges: [{ to: 100 }] };
+					range: { field: "total"; ranges: [{ to: 100 }] };
 					aggs: {
 						by_status: { terms: { field: "status" } };
 					};

--- a/tests/aggregations/metrics/extended_stats.test.ts
+++ b/tests/aggregations/metrics/extended_stats.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
-import type { InvalidFieldInAggregation } from "../../../src/index";
+import type {
+	InvalidFieldInAggregation,
+	InvalidFieldTypeInAggregation,
+} from "../../../src/index";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Extended Stats Aggregations", () => {
@@ -54,6 +57,28 @@ describe("Extended Stats Aggregations", () => {
 					lower_sampling_as_string?: string;
 				};
 			};
+		}>();
+	});
+
+	test("fails when using a non-numeric field", () => {
+		type Aggregations = TestAggregationOutput<
+			"test_types",
+			{
+				price_stats: {
+					extended_stats: {
+						field: "name";
+					};
+				};
+			}
+		>;
+		expectTypeOf<Aggregations["aggregations"]>().toEqualTypeOf<{
+			price_stats: InvalidFieldTypeInAggregation<
+				"name",
+				"test_types",
+				Aggregations["input"]["price_stats"],
+				string,
+				number
+			>;
 		}>();
 	});
 


### PR DESCRIPTION
## Summary
- add field-type validation for numeric aggregations: `extended_stats`, `histogram`, and `range`
- add field-type validation for date aggregations: `auto_date_histogram`, `date_histogram`, and `date_range`
- add type tests and a patch changeset

## Notes
- date aggregations validate against string fields, matching the project convention discussed in the issue for date mappings.

Closes #104