### PR TITLE
Add bucket_selector pipeline aggregation output type

### DIFF
--- a/.changeset/bucket-selector-output.md
+++ b/.changeset/bucket-selector-output.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Export the `bucket_selector` pipeline aggregation output type, which correctly resolves to no response entry because `bucket_selector` only filters parent buckets.

--- a/src/aggregations/pipeline/bucket_selector.ts
+++ b/src/aggregations/pipeline/bucket_selector.ts
@@ -1,0 +1,9 @@
+/**
+ * @see https://www.elastic.co/docs/reference/aggregations/search-aggregations-pipeline-bucket-selector-aggregation
+ *
+ * `bucket_selector` filters buckets from its parent multi-bucket aggregation and
+ * does not add its own entry to the response.
+ */
+export type BucketSelector<Agg> = Agg extends { bucket_selector: object }
+	? never
+	: never;

--- a/src/aggregations/pipeline/index.ts
+++ b/src/aggregations/pipeline/index.ts
@@ -2,6 +2,7 @@ export * from "./avg_bucket";
 export * from "./bucket_correlation";
 export * from "./bucket_count_ks_test";
 export * from "./bucket_script";
+export * from "./bucket_selector";
 export * from "./change_point";
 export * from "./cumulative_cardinality";
 export * from "./cumulative_sum";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -400,6 +400,7 @@ export type AggregationOutput<
 				| Pipeline.BucketCorrelation<Agg>
 				| Pipeline.BucketCountKSTest<Agg>
 				| Pipeline.BucketScript<Agg>
+				| Pipeline.BucketSelector<Agg>
 				| Pipeline.ChangePoint<BaseQuery, Query, E, Index, Agg>
 				| Pipeline.CumulativeCardinality<Agg>
 				| Pipeline.CumulativeSum<Agg>

--- a/tests/aggregations/pipeline/bucket_selector.test.ts
+++ b/tests/aggregations/pipeline/bucket_selector.test.ts
@@ -1,7 +1,19 @@
 import { describe, expectTypeOf, test } from "bun:test";
+import type { BucketSelector } from "../../../src/aggregations/pipeline/bucket_selector";
 import type { TestAggregationOutput } from "../../shared";
 
 describe("Bucket Selector Pipeline Aggregation", () => {
+	test("bucket_selector does not add an output entry", () => {
+		type Output = BucketSelector<{
+			bucket_selector: {
+				buckets_path: { totalSales: "total_sales" };
+				script: "params.totalSales > 200";
+			};
+		}>;
+
+		expectTypeOf<Output>().toEqualTypeOf<never>();
+	});
+
 	test("docs example: retain months with total_sales > 200", () => {
 		type Aggregations = TestAggregationOutput<
 			"demo",


### PR DESCRIPTION
## Summary
- add an explicit `BucketSelector` pipeline aggregation output type
- export `bucket_selector` from pipeline aggregations and include it in `AggregationOutput`
- add a type test confirming `bucket_selector` filters parent buckets without adding a response entry
- add a patch changeset

## Notes
- Elasticsearch documents `bucket_selector` as a parent pipeline aggregation that removes buckets from the parent aggregation response; it does not produce its own output object.

Closes #5
