### PR TITLE
Document full aggregation support

### DIFF
--- a/.changeset/all-aggregations-readme-note.md
+++ b/.changeset/all-aggregations-readme-note.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Document that all tracked Elasticsearch aggregations are supported.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm install -D @vahor/typed-es
 <details>
 <summary>Supported Aggregations</summary>
 
+All Elasticsearch aggregations tracked in this table are supported.
+
 ### Bucket Aggregations
 | Aggregation | Status | Documentation |
 |-------------|--------|---------------|


### PR DESCRIPTION
## Summary
- note in `README.md` that all Elasticsearch aggregations tracked in the support table are supported
- add a patch changeset

## Notes
- README/docs-only follow-up after the last missing aggregation support landed.

Closes #5
