### PR TITLE
Fix _source field validation errors

### DIFF
--- a/.changeset/source-field-validation.md
+++ b/.changeset/source-field-validation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Validate literal `_source` fields in `typedEs`, so invalid fields now report the selected `index` instead of unrelated index fields while preserving wildcard and dynamic string support.

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ const result = await (client as unknown as Client).search<TDocument, TAggregatio
 
 - Query clauses and aggregation field parameters are not fully field-validated yet.
 - Some aggregation functions might be missing.
-- `_source` accepts arbitrary strings to support wildcards. Wildcards still produce the **correct inferred output type**.
+- `_source` accepts typed wildcard patterns and dynamic strings. Wildcards still produce the **correct inferred output type**.
 - Client setup currently requires `as unknown as TypedClient<Indexes>` because the official client types are being augmented.
 - `index` must be a concrete key, `_all`, or a list of concrete keys. Wildcard index names are not supported yet.
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -208,6 +208,11 @@ export type PossibleFieldsWithWildcards<
 	OnlyLeaf = false,
 > = PossibleFields<Index, Indexes, OnlyLeaf> | AnyString;
 
+export type {
+	InvalidSourceField,
+	ValidateTypedSearchRequest,
+} from "./types/source-validation";
+
 export type TypeOfField<
 	Field extends string,
 	Indexes extends ElasticsearchIndexes,

--- a/src/typed-es.ts
+++ b/src/typed-es.ts
@@ -4,6 +4,7 @@ import type {
 	OverwrittenSearchRequestFields,
 	TypedClient,
 	TypedSearchRequest,
+	ValidateTypedSearchRequest,
 } from ".";
 
 /**
@@ -80,7 +81,7 @@ export function typedEs<
 	const Query extends TypedSearchRequest<Indexes>,
 >(
 	_client: TypedClient<Indexes>,
-	query: Query,
+	query: Query & ValidateTypedSearchRequest<Indexes, Query>,
 ): Query & Omit<estypes.SearchRequest, OverwrittenSearchRequestFields> {
 	return query as Query &
 		Omit<estypes.SearchRequest, OverwrittenSearchRequestFields>;

--- a/src/types/source-validation.ts
+++ b/src/types/source-validation.ts
@@ -1,0 +1,86 @@
+import type {
+	ElasticsearchIndexes,
+	PossibleFields,
+	RequestedIndex,
+} from "../lib";
+import type { IsNever, IsStringLiteral } from "./helpers";
+import type { WildcardSearch } from "./wildcard-search";
+
+export type InvalidSourceField<
+	Field extends string,
+	Index extends string,
+> = Field & {
+	readonly __typedEs_error__: `\`${Field}\` is not a valid \`_source\` field for \`${Index}\``;
+};
+
+type ValidSourceFieldVariant<
+	Index extends string,
+	Indexes extends ElasticsearchIndexes,
+> = `${PossibleFields<Index, Indexes, true>}.${string}`;
+
+type ValidateSourceField<
+	Field,
+	Index extends string,
+	Indexes extends ElasticsearchIndexes,
+> = Field extends string
+	? IsStringLiteral<Field> extends false
+		? Field
+		: Field extends PossibleFields<Index, Indexes, false, true>
+			? Field
+			: Field extends ValidSourceFieldVariant<Index, Indexes>
+				? Field
+				: Field extends `${string}*${string}`
+					? IsNever<
+							WildcardSearch<PossibleFields<Index, Indexes>, Field>
+						> extends true
+						? InvalidSourceField<Field, Index>
+						: Field
+					: InvalidSourceField<Field, Index>
+	: Field;
+
+type ValidateSourceFieldList<
+	Fields,
+	Index extends string,
+	Indexes extends ElasticsearchIndexes,
+> = Fields extends readonly unknown[]
+	? {
+			[K in keyof Fields]: K extends number | `${number}`
+				? ValidateSourceField<Fields[K], Index, Indexes>
+				: Fields[K];
+		}
+	: Fields;
+
+type ValidateSourceObject<
+	Source,
+	Index extends string,
+	Indexes extends ElasticsearchIndexes,
+> = {
+	[K in keyof Source]: K extends "includes" | "include" | "excludes" | "exclude"
+		? ValidateSourceFieldList<Source[K], Index, Indexes>
+		: Source[K];
+};
+
+type ValidateSource<
+	Source,
+	Index extends string,
+	Indexes extends ElasticsearchIndexes,
+> = Source extends false
+	? Source
+	: Source extends readonly unknown[]
+		? ValidateSourceFieldList<Source, Index, Indexes>
+		: Source extends object
+			? ValidateSourceObject<Source, Index, Indexes>
+			: Source;
+
+export type ValidateTypedSearchRequest<
+	Indexes extends ElasticsearchIndexes,
+	Query,
+> = Query extends { _source: infer Source }
+	? {
+			_source: ValidateSource<
+				Source,
+				Extract<RequestedIndex<Query>, string>,
+				Indexes
+			>;
+		}
+	: unknown;

--- a/tests/override/search-response.test.ts
+++ b/tests/override/search-response.test.ts
@@ -111,10 +111,10 @@ describe("Should return the correct type", () => {
 					});
 
 					test("on an unknown field", () => {
-						const query = typedEs(client, {
+						const query = {
 							index: "demo",
 							_source: ["entity_id.keyword", "invalid"],
-						});
+						} as const satisfies SearchRequest;
 						type OutputSource = TypedSearchResponse<
 							typeof query,
 							CustomIndexes
@@ -145,10 +145,10 @@ describe("Should return the correct type", () => {
 					});
 
 					test("on the object itself", () => {
-						const query = typedEs(client, {
+						const query = {
 							index: "orders",
 							_source: ["shipping_address.keyword"],
-						});
+						} as const satisfies SearchRequest;
 						type OutputSource = TypedSearchResponse<
 							typeof query,
 							CustomIndexes
@@ -158,13 +158,13 @@ describe("Should return the correct type", () => {
 					});
 
 					test("on the object itself, but also querying for a leaf field", () => {
-						const query = typedEs(client, {
+						const query = {
 							index: "orders",
 							_source: [
 								"shipping_address.keyword",
 								"shipping_address.postal_code.keyword",
 							],
-						});
+						} as const satisfies SearchRequest;
 						type OutputSource = TypedSearchResponse<
 							typeof query,
 							CustomIndexes

--- a/tests/reproductions/3.test.ts
+++ b/tests/reproductions/3.test.ts
@@ -1,0 +1,44 @@
+import { describe, test } from "bun:test";
+import { typedEs } from "../../src";
+import { client } from "../shared";
+
+describe("3", () => {
+	test("validates literal _source fields against the selected index", () => {
+		typedEs(client, {
+			index: "demo",
+			_source: ["score", "entity_id.keyword", "*ate"],
+		});
+
+		typedEs(client, {
+			index: "demo",
+			// @ts-expect-error: `invalid` is not a valid `_source` field for `demo`
+			_source: ["score", "invalid"],
+		});
+
+		typedEs(client, {
+			index: "demo",
+			// @ts-expect-error: `missing*` does not match any `_source` field for `demo`
+			_source: ["missing*"],
+		});
+	});
+
+	test("validates literal _source filters against the selected index", () => {
+		typedEs(client, {
+			index: "orders",
+			_source: {
+				includes: ["shipping_address.street", "created_*"],
+				// @ts-expect-error: `score` is not a valid `_source` field for `orders`
+				excludes: ["score"],
+			},
+		});
+	});
+
+	test("allows dynamic field strings", () => {
+		const field = "score" as string;
+
+		typedEs(client, {
+			index: "demo",
+			_source: [field],
+		});
+	});
+});

--- a/tests/typed-es.test.ts
+++ b/tests/typed-es.test.ts
@@ -57,6 +57,7 @@ describe("typedEs Function", () => {
 		test("with invalid fields", () => {
 			typedEs(client, {
 				index: "demo",
+				// @ts-expect-error: `invalid` is not a valid `_source` field for `demo`
 				_source: ["score", "invalid"],
 			});
 		});


### PR DESCRIPTION
## Summary
- add literal `_source` field validation in `typedEs` so invalid fields are checked against the selected `index`
- preserve valid wildcards, field variants, and dynamic string values
- add reproduction coverage for issue #3 and a patch changeset

## Notes
- Raw `SearchRequest` response-shape tests still cover unknown source selections separately from `typedEs` request validation.

Closes #3