### PR TITLE
refactor: clean up response override types

### DIFF
--- a/.changeset/clean-response-type-overrides.md
+++ b/.changeset/clean-response-type-overrides.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Clean up response override helper types and remove unnecessary type suppressions.

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,17 +73,7 @@ export interface TypedClient<E extends ElasticsearchIndexes> extends Client {
 	search<
 		Query extends TypedSearchRequest<E>,
 		O extends TransportOptions = TransportRequestOptionsWithOutMeta,
-	>(
-		query: Query,
-		options?: O,
-	): WithTransport<
-		O,
-		TypedSearchResponse<
-			// @ts-expect-error: Same as above
-			Query,
-			E
-		>
-	>;
+	>(query: Query, options?: O): WithTransport<O, TypedSearchResponse<Query, E>>;
 
 	/**
 	 * Run multiple independent searches in a single request.
@@ -108,14 +98,7 @@ export interface TypedClient<E extends ElasticsearchIndexes> extends Client {
 		>(
 			params: estypes.AsyncSearchGetRequest,
 			options?: O,
-		): WithTransport<
-			O,
-			TypedAsyncSearchGetResponse<
-				// @ts-expect-error: Same as above
-				Query,
-				E
-			>
-		>;
+		): WithTransport<O, TypedAsyncSearchGetResponse<Query, E>>;
 
 		/**
 		 * Run an async search. When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested. Warning: Asynchronous search does not support scroll or search requests that include only the suggest section. By default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error. The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
@@ -127,13 +110,6 @@ export interface TypedClient<E extends ElasticsearchIndexes> extends Client {
 		>(
 			params: Query,
 			options?: O,
-		): WithTransport<
-			O,
-			TypedAsyncSearchSubmitResponse<
-				// @ts-expect-error: Same as above
-				Query,
-				E
-			>
-		>;
+		): WithTransport<O, TypedAsyncSearchSubmitResponse<Query, E>>;
 	};
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -610,16 +610,47 @@ export type OverwrittenSearchRequestFields =
 	| "sort"
 	| "query";
 
+type SearchSourceRequest<Field extends string> =
+	| RArray<Field>
+	| false
+	| {
+			includes?: RArray<Field>;
+			include?: RArray<Field>;
+			excludes?: RArray<Field>;
+			exclude?: RArray<Field>;
+	  };
+
+type SearchFieldsRequest<Field extends string> = RArray<
+	| Field
+	| {
+			field: Field;
+			format?: string;
+	  }
+>;
+
 export type SearchRequest = Pick<
 	estypes.SearchRequest,
 	Exclude<OverwrittenSearchRequestFields, IssueWithReadonlyArray>
->;
+> & {
+	index?: estypes.SearchRequest["index"] | RArray<string>;
+	_source?: estypes.SearchRequest["_source"] | SearchSourceRequest<string>;
+	fields?: estypes.SearchRequest["fields"] | SearchFieldsRequest<string>;
+	docvalue_fields?:
+		| estypes.SearchRequest["docvalue_fields"]
+		| SearchFieldsRequest<string>;
+};
 
 /**
- * HACK: const Query modifier cause sort/query to be readonly. which cause issues with estypes versions as it has mutable arrays in types.
- * The correct fix would be to overrides these types but as we don't really have to, we simply skip them.
+ * HACK: const Query modifier cause some search options to be readonly. which cause issues with estypes versions as it has mutable arrays in types.
+ * The correct fix would be to override these types but as we don't really have to, we simply skip them.
  */
-type IssueWithReadonlyArray = "sort" | "query";
+type IssueWithReadonlyArray =
+	| "sort"
+	| "query"
+	| "index"
+	| "_source"
+	| "fields"
+	| "docvalue_fields";
 
 /**
  * A type-safe Elasticsearch search request that provides autocomplete and validation
@@ -664,28 +695,12 @@ type TypedSearchRequestForIndex<
 	IndexInput = Index,
 > = {
 	index: IndexInput;
-	_source?:
-		| RArray<PossibleFieldsWithWildcards<Index, Indexes>>
-		| false
-		| {
-				includes?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
-				include?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
-				excludes?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
-				exclude?: RArray<PossibleFieldsWithWildcards<Index, Indexes>>;
-		  };
-	fields?: RArray<
-		| PossibleFieldsWithWildcards<Index, Indexes, true>
-		| {
-				field: PossibleFieldsWithWildcards<Index, Indexes, true>;
-				format?: string;
-		  }
+	_source?: SearchSourceRequest<PossibleFieldsWithWildcards<Index, Indexes>>;
+	fields?: SearchFieldsRequest<
+		PossibleFieldsWithWildcards<Index, Indexes, true>
 	>;
-	docvalue_fields?: RArray<
-		| PossibleFieldsWithWildcards<Index, Indexes, true>
-		| {
-				field: PossibleFieldsWithWildcards<Index, Indexes, true>;
-				format?: string;
-		  }
+	docvalue_fields?: SearchFieldsRequest<
+		PossibleFieldsWithWildcards<Index, Indexes, true>
 	>;
 };
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -422,6 +422,24 @@ export type AggregationOutput<
 				| Pipeline.StatsBucket<Agg>
 				| Pipeline.SumBucket<Agg>;
 
+export type AggregationOutputs<
+	BaseQuery extends SearchRequest,
+	Query extends Record<string, unknown>,
+	E extends ElasticsearchIndexes,
+	Index extends string = RequestedIndex<Query>,
+> =
+	IsNever<ExtractAggs<Query>> extends true
+		? never
+		: {
+				[K in Extract<keyof ExtractAggs<Query>, string>]: AggregationOutput<
+					BaseQuery,
+					Query,
+					E,
+					K,
+					Index
+				>;
+			};
+
 export type AppendSubAggs<
 	BaseQuery extends SearchRequest,
 	E extends ElasticsearchIndexes,

--- a/src/override/async-search-get-response.ts
+++ b/src/override/async-search-get-response.ts
@@ -1,10 +1,9 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
-	AggregationOutput,
+	AggregationOutputs,
 	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	ElasticsearchOutputFields,
-	ExtractAggsKey,
 	RequestedIndex,
 	SearchRequest,
 } from "../lib";
@@ -54,15 +53,6 @@ export type TypedAsyncSearchGetResponse<
 				E,
 				ElasticsearchOutputFields<Query, E, Index, "_source">,
 				ElasticsearchOutputFields<Query, E, Index, "fields">,
-				{
-					[K in ExtractAggsKey<Query>]: AggregationOutput<
-						Query,
-						Query,
-						E,
-						// @ts-expect-error: TODO
-						K,
-						Index
-					>;
-				}
+				AggregationOutputs<Query, Query, E, Index>
 			>
 		: `Index '${Index}' not found`;

--- a/src/override/async-search-submit-response.ts
+++ b/src/override/async-search-submit-response.ts
@@ -1,10 +1,9 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
-	AggregationOutput,
+	AggregationOutputs,
 	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	ElasticsearchOutputFields,
-	ExtractAggsKey,
 	RequestedIndex,
 	SearchRequest,
 } from "../lib";
@@ -54,15 +53,6 @@ export type TypedAsyncSearchSubmitResponse<
 				E,
 				ElasticsearchOutputFields<Query, E, Index, "_source">,
 				ElasticsearchOutputFields<Query, E, Index, "fields">,
-				{
-					[K in ExtractAggsKey<Query>]: AggregationOutput<
-						Query,
-						Query,
-						E,
-						// @ts-expect-error: TODO
-						K,
-						Index
-					>;
-				}
+				AggregationOutputs<Query, Query, E, Index>
 			>
 		: `Index '${Index}' not found`;

--- a/src/override/msearch-response.ts
+++ b/src/override/msearch-response.ts
@@ -3,12 +3,12 @@ import type {
 	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	RequestedIndex,
+	SearchRequest,
 	TypedSearchRequest,
 } from "../lib";
 import type {
 	AlternatingPair,
 	IsNever,
-	MergeProperties,
 	Prettify,
 	RArray,
 	UnionToIntersection,
@@ -25,6 +25,15 @@ type PopPair<Data> = Data extends [infer H, infer T, ...infer Rest]
 	? { header: H; request: T; rest: Rest }
 	: never;
 
+type PairFromSearchItem<T> = PopPair<
+	[
+		"index" extends keyof UnionToIntersection<T>
+			? Pick<UnionToIntersection<T>, "index">
+			: {},
+		Prettify<Omit<UnionToIntersection<T>, "index">>,
+	]
+>;
+
 type ExtractAllPairs<Data> = Data extends readonly [
 	infer H,
 	infer T,
@@ -39,19 +48,7 @@ type ExtractAllPairs<Data> = Data extends readonly [
 	: Data extends Array<infer T>
 		? IsNever<T> extends true
 			? []
-			: [
-					{
-						// TODO: make this pretty
-						data: PopPair<
-							[
-								"index" extends keyof UnionToIntersection<T>
-									? Pick<UnionToIntersection<T>, "index">
-									: {},
-								Prettify<Omit<UnionToIntersection<T>, "index">>,
-							]
-						>;
-					},
-				]
+			: [{ data: PairFromSearchItem<T> }]
 		: [];
 
 export type TypedMsearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
@@ -85,6 +82,30 @@ type ParsedSearches<
 			: never;
 };
 
+type InheritRestTotalHitsAsInt<Search, Parent> = Search extends {
+	rest_total_hits_as_int: unknown;
+}
+	? Search
+	: Parent extends { rest_total_hits_as_int: infer RestTotalHitsAsInt }
+		? Search & { rest_total_hits_as_int: RestTotalHitsAsInt }
+		: Search;
+
+type TypedMSearchResponseForPair<
+	Query extends TypedMsearchRequest<E>,
+	E extends ElasticsearchIndexes,
+	Pair,
+> = Pair extends {
+	Index: infer Index extends string;
+	Query: infer Search extends SearchRequest;
+}
+	? { index: Index } & Omit<
+			InheritRestTotalHitsAsInt<Search, Query>,
+			"index"
+		> extends infer ResponseQuery extends SearchRequest
+		? TypedSearchResponse<ResponseQuery, E>
+		: never
+	: never;
+
 export type TypedMSearchResponse<
 	Query extends TypedMsearchRequest<E>,
 	E extends ElasticsearchIndexes,
@@ -92,20 +113,7 @@ export type TypedMSearchResponse<
 > = Omit<estypes.MsearchResponse, "responses"> & {
 	responses: {
 		[Index in keyof Pairs]:
-			| TypedSearchResponse<
-					// @ts-expect-error: TODO: see why ts is no happy about this
-					{ index: Pairs[Index]["Index"] } & Omit<
-						MergeProperties<
-							// @ts-expect-error: TODO: see why ts is no happy about this
-							Pairs[Index]["Query"],
-							Query,
-							// @ts-expect-error: Same issue as above
-							"rest_total_hits_as_int"
-						>,
-						"index"
-					>,
-					E
-			  >
+			| TypedMSearchResponseForPair<Query, E, Pairs[Index]>
 			| (estypes.ErrorResponseBase & { hits: undefined });
 	};
 };

--- a/src/override/search-response.ts
+++ b/src/override/search-response.ts
@@ -1,11 +1,10 @@
 import type { estypes } from "@elastic/elasticsearch";
 import type {
-	AggregationOutput,
+	AggregationOutputs,
 	ElasticsearchIndex,
 	ElasticsearchIndexes,
 	ElasticsearchOutputFields,
 	ExtractAggs,
-	ExtractAggsKey,
 	ExtractHasChildInnerHitsKeys,
 	ExtractScriptFieldsKeys,
 	InnerHitsQueryTotal,
@@ -117,15 +116,6 @@ export type TypedSearchResponse<
 				ElasticsearchOutputFields<Query, E, Index, "_source">,
 				ElasticsearchOutputFields<Query, E, Index, "fields">,
 				ExtractScriptFieldsKeys<Query>,
-				{
-					[K in ExtractAggsKey<Query>]: AggregationOutput<
-						Query,
-						Query,
-						E,
-						// @ts-expect-error: TODO
-						K,
-						Index
-					>;
-				}
+				AggregationOutputs<Query, Query, E, Index>
 			>
 		: `Index '${Index}' not found`;


### PR DESCRIPTION
## Summary
- support readonly request values in internal `SearchRequest` without duplicating `TypedSearchRequestForIndex` field shapes
- add a shared `AggregationOutputs` helper for search and async search response aggregation typing
- simplify `TypedMSearchResponse` pair handling and inherited `rest_total_hits_as_int` typing
- remove unnecessary response type `@ts-expect-error` suppressions
- add a patch changeset

## Notes
- This is a type-only cleanup; runtime behavior is unchanged.
- The remaining `TypedClient extends Client` suppression is intentional and unrelated to the response override TODOs.

## Validation
- `AGENT=1 bun test`
- `bun typecheck`
