### PR TITLE
Refactor type cleanup

### DIFF
--- a/.changeset/code-cleanup.md
+++ b/.changeset/code-cleanup.md
@@ -2,4 +2,4 @@
 "@vahor/typed-es": patch
 ---
 
-Refactor type helpers for requested fields, output fields, and typed client overrides.
+Refactor type helpers for requested fields, output fields, and typed client overrides, and remove the legacy `ExtractQuery_Source` export.

--- a/.changeset/code-cleanup.md
+++ b/.changeset/code-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Refactor type helpers for requested fields, output fields, and typed client overrides.

--- a/src/client.ts
+++ b/src/client.ts
@@ -64,8 +64,10 @@ type WithTransport<
  * the native Elasticsearch Client with stricter type definitions. This is safe and provides
  * better type checking for your queries and results.
  */
-// @ts-expect-error: We are overriding types, but it's fine
-export interface TypedClient<E extends ElasticsearchIndexes> extends Client {
+export type TypedClient<E extends ElasticsearchIndexes> = Omit<
+	Client,
+	"search" | "msearch" | "asyncSearch"
+> & {
 	/**
 	 * Run a search. Get search hits that match the query defined in the request. You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used. If the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges. To search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices. **Search slicing** When paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties. By default the splitting is done first on the shards, then locally on each shard. The local splitting partitions the shard into contiguous ranges based on Lucene document IDs. For instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard. IMPORTANT: The same point-in-time ID should be used for all slices. If different PIT IDs are used, slices can overlap and miss documents. This situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.
 	 * @see {@link https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search | Elasticsearch API documentation}
@@ -112,4 +114,4 @@ export interface TypedClient<E extends ElasticsearchIndexes> extends Client {
 			options?: O,
 		): WithTransport<O, TypedAsyncSearchSubmitResponse<Query, E>>;
 	};
-}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ export * from "./client";
 export * from "./lib";
 export * from "./typed-es";
 export type {
-	ExtractQuery_Source,
 	ExtractQueryFields,
 	ExtractQuerySource,
 } from "./types/requested-fields";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./client";
 export * from "./lib";
 export * from "./typed-es";
 export type {
-	ExtractQuery_Source, // TODO: should probably be renamed if we want to export it
+	ExtractQuery_Source,
 	ExtractQueryFields,
+	ExtractQuerySource,
 } from "./types/requested-fields";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,15 +15,14 @@ import type {
 	UnionToIntersection,
 } from "./types/helpers";
 import type {
-	FLAT_UNKNOWN,
 	JoinKeys,
 	Primitive,
 	RecursiveDotNotation,
 	RemoveLastDot,
 } from "./types/object-to-dot-notation";
 import type {
-	ExtractQuery_Source,
 	ExtractQueryFields,
+	ExtractQuerySource,
 } from "./types/requested-fields";
 import type {
 	InverseWildcardSearch,
@@ -539,6 +538,20 @@ type DeepPickFieldsForIndex<
 		? DeepPickPaths<E[Index], DeepPickPathsForIndex<E, Index, Paths>>
 		: never;
 
+type FieldVariantFields<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	PossibleFieldPaths,
+	RequestedFields,
+> =
+	InverseWildcardSearch<PossibleFieldPaths, RequestedFields> extends infer Field
+		? Field extends string
+			? IsParentKeyALeaf<Field, E, Index> extends true
+				? Field
+				: never
+			: never
+		: never;
+
 export type ElasticsearchOutputFields<
 	QueryWithSource extends Partial<SearchRequest>,
 	E extends ElasticsearchIndexes,
@@ -546,33 +559,35 @@ export type ElasticsearchOutputFields<
 	Type extends "_source" | "fields",
 	//
 	RequestedFields = Type extends "_source"
-		? ExtractQuery_Source<
+		? ExtractQuerySource<
 				QueryWithSource,
 				E,
 				Index,
 				Index extends keyof E ? keyof E[Index] : PossibleFields<Index, E>
 			>
 		: ExtractQueryFields<QueryWithSource>,
-	// TODO: make this a union string instead of an object. we no longer need the values
-	Output = {
-		[K in WildcardSearch<
-			PossibleFields<Index, E, Type extends "fields" ? true : false>,
-			RequestedFields
-		>]: TypeOfField<K, E, Index>;
-	} & {
-		[K in InverseWildcardSearch<
-			PossibleFields<Index, E, Type extends "fields" ? true : false>,
-			RequestedFields
-		> as IsParentKeyALeaf<K, E, Index> extends true ? K : never]: FLAT_UNKNOWN;
-	},
+	PossibleFieldPaths = PossibleFields<
+		Index,
+		E,
+		Type extends "fields" ? true : false
+	>,
+	MatchedFields = WildcardSearch<PossibleFieldPaths, RequestedFields>,
+	// Elasticsearch accepts variant names like `field.keyword`; keep them when the base `field` exists as a leaf.
+	VariantFields = FieldVariantFields<
+		E,
+		Index,
+		PossibleFieldPaths,
+		RequestedFields
+	>,
+	OutputFields = MatchedFields | VariantFields,
 > = Type extends "_source"
-	? DeepPickFieldsForIndex<E, Index, Extract<keyof Output, string>>
+	? DeepPickFieldsForIndex<E, Index, Extract<OutputFields, string>>
 	: {
-			[K in keyof Output as Output[K] extends FLAT_UNKNOWN
+			[K in Extract<OutputFields, string> as K extends VariantFields
 				? RemoveLastDot<K>
-				: K]: Output[K] extends FLAT_UNKNOWN
+				: K]: K extends VariantFields
 				? Array<unknown>
-				: Array<Output[K]>;
+				: Array<TypeOfField<K, E, Index>>;
 		};
 
 export type ExtractScriptFieldsKeys<Query extends SearchRequest> =

--- a/src/types/requested-fields.ts
+++ b/src/types/requested-fields.ts
@@ -32,14 +32,6 @@ export type ExtractQuerySource<
 			? never
 			: AllFields;
 
-export type ExtractQuery_Source<
-	Query extends Record<string, unknown>,
-	Indexes,
-	Index extends string = RequestedIndex<Query>,
-	AllFields = Index extends keyof Indexes ? keyof Indexes[Index] : never,
-	Source = Query["_source"],
-> = ExtractQuerySource<Query, Indexes, Index, AllFields, Source>;
-
 type FieldRequestName<Field> = Field extends string
 	? Field
 	: Field extends { field: infer Name extends string }

--- a/src/types/requested-fields.ts
+++ b/src/types/requested-fields.ts
@@ -1,13 +1,21 @@
 import type { RequestedIndex } from "../lib";
 import type { GetField, IsNever } from "./helpers";
 
-type InferSource<T, Key extends string> = T extends {
-	[k in Key]: (infer A)[];
-}
-	? A
+type SourceFilterKey = "includes" | "include" | "excludes" | "exclude";
+type SourceFilter = Partial<Record<SourceFilterKey, readonly string[]>>;
+
+type SourceFilterValue<T, Key extends SourceFilterKey> = Key extends string
+	? T extends { [K in Key]: readonly (infer Field extends string)[] }
+		? Field
+		: never
 	: never;
 
-export type ExtractQuery_Source<
+type SourceIncludeFields<Source, AllFields> =
+	IsNever<SourceFilterValue<Source, "includes" | "include">> extends true
+		? AllFields
+		: SourceFilterValue<Source, "includes" | "include">;
+
+export type ExtractQuerySource<
 	Query extends Record<string, unknown>,
 	Indexes,
 	Index extends string = RequestedIndex<Query>,
@@ -15,33 +23,30 @@ export type ExtractQuery_Source<
 	Source = Query["_source"],
 > = Source extends readonly (infer Fields extends string)[]
 	? Fields
-	: Source extends {
-				includes?: string[];
-				include?: string[];
-				excludes?: string[];
-				exclude?: string[];
-			}
+	: Source extends SourceFilter
 		? Exclude<
-				// TODO: check if we can do this better
-					| InferSource<Source, "includes">
-					| IsNever<InferSource<Source, "include">> extends true
-					? AllFields
-					: InferSource<Source, "includes"> | InferSource<Source, "include">,
-				InferSource<Source, "excludes"> | InferSource<Source, "exclude">
+				SourceIncludeFields<Source, AllFields>,
+				SourceFilterValue<Source, "excludes" | "exclude">
 			>
 		: Source extends false
 			? never
 			: AllFields;
 
+export type ExtractQuery_Source<
+	Query extends Record<string, unknown>,
+	Indexes,
+	Index extends string = RequestedIndex<Query>,
+	AllFields = Index extends keyof Indexes ? keyof Indexes[Index] : never,
+	Source = Query["_source"],
+> = ExtractQuerySource<Query, Indexes, Index, AllFields, Source>;
+
+type FieldRequestName<Field> = Field extends string
+	? Field
+	: Field extends { field: infer Name extends string }
+		? Name
+		: never;
+
 export type ExtractQueryFields<
 	Query extends Record<string, unknown>,
 	Fields = GetField<Query, "fields"> | GetField<Query, "docvalue_fields">,
-> = Fields extends readonly (infer FieldsItem extends
-	| string
-	| { field: string })[]
-	?
-			| Extract<FieldsItem, string>
-			| {
-					[k in Extract<FieldsItem, { field: string }>["field"]]: k;
-			  }[Extract<FieldsItem, { field: string }>["field"]]
-	: never;
+> = Fields extends readonly (infer Field)[] ? FieldRequestName<Field> : never;

--- a/tests/field-extraction.test.ts
+++ b/tests/field-extraction.test.ts
@@ -2,8 +2,8 @@ import { describe, expectTypeOf, test } from "bun:test";
 import type { RequestedIndex, SearchRequest } from "../src/index";
 import type { TypedSearchResponse } from "../src/override/search-response";
 import type {
-	ExtractQuery_Source,
 	ExtractQueryFields,
+	ExtractQuerySource,
 } from "../src/types/requested-fields";
 import type { CustomIndexes, testQueries } from "./shared";
 
@@ -15,7 +15,7 @@ describe("Field Extraction", () => {
 				_source: ["score", "invalid"],
 			} as const satisfies SearchRequest;
 			expectTypeOf<
-				ExtractQuery_Source<typeof query, CustomIndexes>
+				ExtractQuerySource<typeof query, CustomIndexes>
 			>().toEqualTypeOf<"score" | "invalid">();
 		});
 
@@ -24,7 +24,7 @@ describe("Field Extraction", () => {
 				index: "demo",
 			} as const satisfies SearchRequest;
 			expectTypeOf<
-				ExtractQuery_Source<typeof query, CustomIndexes>
+				ExtractQuerySource<typeof query, CustomIndexes>
 			>().toEqualTypeOf<keyof CustomIndexes["demo"]>();
 		});
 
@@ -34,7 +34,7 @@ describe("Field Extraction", () => {
 				_source: false,
 			} as const satisfies SearchRequest;
 			expectTypeOf<
-				ExtractQuery_Source<typeof query, CustomIndexes>
+				ExtractQuerySource<typeof query, CustomIndexes>
 			>().toEqualTypeOf<never>();
 		});
 
@@ -47,7 +47,7 @@ describe("Field Extraction", () => {
 					},
 				} as const satisfies SearchRequest;
 				expectTypeOf<
-					ExtractQuery_Source<typeof query, CustomIndexes>
+					ExtractQuerySource<typeof query, CustomIndexes>
 				>().toEqualTypeOf<"score" | "invalid">();
 			});
 
@@ -59,7 +59,7 @@ describe("Field Extraction", () => {
 					},
 				} as const satisfies SearchRequest;
 				expectTypeOf<
-					ExtractQuery_Source<typeof query, CustomIndexes>
+					ExtractQuerySource<typeof query, CustomIndexes>
 				>().toEqualTypeOf<Exclude<keyof CustomIndexes["demo"], "score">>();
 			});
 			test("with _source.includes and _source.excludes", () => {
@@ -71,7 +71,7 @@ describe("Field Extraction", () => {
 					},
 				} as const satisfies SearchRequest;
 				expectTypeOf<
-					ExtractQuery_Source<typeof query, CustomIndexes>
+					ExtractQuerySource<typeof query, CustomIndexes>
 				>().toEqualTypeOf<never>();
 			});
 		});

--- a/tests/requested-fields.test.ts
+++ b/tests/requested-fields.test.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "bun:test";
 import {
-	type ExtractQuery_Source,
 	type ExtractQueryFields,
+	type ExtractQuerySource,
 	typedEs,
 } from "../src/index";
 import { type CustomIndexes, client } from "./shared";
@@ -15,7 +15,7 @@ describe("RequestedFields", () => {
 
 		expectTypeOf<ExtractQueryFields<typeof query>>().toEqualTypeOf<never>();
 		expectTypeOf<
-			ExtractQuery_Source<typeof query, CustomIndexes>
+			ExtractQuerySource<typeof query, CustomIndexes>
 		>().toEqualTypeOf<Expected>();
 	});
 
@@ -28,7 +28,7 @@ describe("RequestedFields", () => {
 
 		expectTypeOf<ExtractQueryFields<typeof query>>().toEqualTypeOf<never>();
 		expectTypeOf<
-			ExtractQuery_Source<typeof query, CustomIndexes>
+			ExtractQuerySource<typeof query, CustomIndexes>
 		>().toEqualTypeOf<never>();
 	});
 
@@ -41,7 +41,7 @@ describe("RequestedFields", () => {
 
 		expectTypeOf<ExtractQueryFields<typeof query>>().toEqualTypeOf<never>();
 		expectTypeOf<
-			ExtractQuery_Source<typeof query, CustomIndexes>
+			ExtractQuerySource<typeof query, CustomIndexes>
 		>().toEqualTypeOf<Expected>();
 	});
 
@@ -62,7 +62,7 @@ describe("RequestedFields", () => {
 			"shipping_address.street" | "*_at"
 		>();
 		expectTypeOf<
-			ExtractQuery_Source<typeof query, CustomIndexes>
+			ExtractQuerySource<typeof query, CustomIndexes>
 		>().toEqualTypeOf<"user_id">();
 	});
 
@@ -77,7 +77,7 @@ describe("RequestedFields", () => {
 
 		expectTypeOf<ExtractQueryFields<typeof query>>().toEqualTypeOf<Expected>();
 		expectTypeOf<
-			ExtractQuery_Source<typeof query, CustomIndexes>
+			ExtractQuerySource<typeof query, CustomIndexes>
 		>().toEqualTypeOf<never>();
 	});
 });


### PR DESCRIPTION
## Summary
- remove the `TypedClient` override suppression by omitting native methods before redefining typed ones
- simplify requested `_source`, `fields`, and `docvalue_fields` extraction helpers
- remove the legacy `ExtractQuery_Source` export in favor of `ExtractQuerySource`
- simplify output field selection by using field-name unions instead of sentinel object values
- add a patch changeset

## Tests
- `bunx @biomejs/biome check ./`
- `bun typecheck`
- `AGENT=1 bun test`
- `bun run build`
