### PR TITLE
chore: publish through changesets for provenance

### DIFF
--- a/.changeset/add-publish-provenance.md
+++ b/.changeset/add-publish-provenance.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Add npm publish provenance by publishing releases through Changesets.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"format": "bunx @biomejs/biome check ./ --write",
 		"typecheck": "tsc --noEmit --declaration",
 		"ci:version": "bunx @changesets/cli version",
-		"ci:publish": "bun run build && bun publish && bunx changeset tag"
+		"ci:publish": "bun run build && bunx @changesets/cli publish"
 	},
 	"lint-staged": {
 		"*": [


### PR DESCRIPTION
## Summary
- publish releases through Changesets after building
- add a patch changeset for npm publish provenance

## Notes
- Changesets publishes via the npm CLI, so `NPM_CONFIG_PROVENANCE=true` can create npm provenance attestations.
- Unrelated local `.claude/` and `.mcp.json` files are not included.