### PR TITLE
add support for "nested" array items

### DIFF
--- a/.changeset/fix-fields-object-array.md
+++ b/.changeset/fix-fields-object-array.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Fix `fields` output typing for paths inside "nested" object arrays.

--- a/.changeset/fix-fields-object-array.md
+++ b/.changeset/fix-fields-object-array.md
@@ -2,4 +2,4 @@
 "@vahor/typed-es": patch
 ---
 
-Fix `fields` output typing for paths inside "nested" object arrays.
+Fix `fields` and `_source` output typing for paths inside nested object arrays.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -20,6 +20,10 @@ import type {
 	RemoveLastDot,
 } from "./types/object-to-dot-notation";
 import type {
+	FieldsOutputForSchema,
+	MergeFieldsOutputEntries,
+} from "./types/output-fields";
+import type {
 	ExtractQueryFields,
 	ExtractQuerySource,
 } from "./types/requested-fields";
@@ -512,6 +516,49 @@ type FieldVariantFields<
 			: never
 		: never;
 
+type FieldsOutputForIndex<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Field extends string,
+	Value,
+> = Index extends AllIndex
+	? {
+			[K in Extract<keyof E, string>]: FieldsOutputForSchema<
+				E[K],
+				Field,
+				Value
+			>;
+		}[Extract<keyof E, string>]
+	: Index extends keyof E
+		? FieldsOutputForSchema<E[Index], Field, Value>
+		: Record<Field, Value>;
+
+type FieldsOutputEntry<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	Field extends string,
+	VariantFields,
+> = Field extends VariantFields
+	? RemoveLastDot<Field> extends infer BaseField extends string
+		? FieldsOutputForIndex<E, Index, BaseField, unknown[]>
+		: never
+	: FieldsOutputForIndex<E, Index, Field, Array<TypeOfField<Field, E, Index>>>;
+
+type ElasticsearchFieldsResult<
+	E extends ElasticsearchIndexes,
+	Index extends string,
+	OutputFields,
+	VariantFields,
+	Field extends string = Extract<OutputFields, string>,
+> =
+	IsNever<Field> extends true
+		? {}
+		: MergeFieldsOutputEntries<
+				Field extends string
+					? FieldsOutputEntry<E, Index, Field, VariantFields>
+					: never
+			>;
+
 export type ElasticsearchOutputFields<
 	QueryWithSource extends Partial<SearchRequest>,
 	E extends ElasticsearchIndexes,
@@ -542,13 +589,7 @@ export type ElasticsearchOutputFields<
 	OutputFields = MatchedFields | VariantFields,
 > = Type extends "_source"
 	? DeepPickFieldsForIndex<E, Index, Extract<OutputFields, string>>
-	: {
-			[K in Extract<OutputFields, string> as K extends VariantFields
-				? RemoveLastDot<K>
-				: K]: K extends VariantFields
-				? Array<unknown>
-				: Array<TypeOfField<K, E, Index>>;
-		};
+	: ElasticsearchFieldsResult<E, Index, OutputFields, VariantFields>;
 
 export type ExtractScriptFieldsKeys<Query extends SearchRequest> =
 	Query extends {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -14,8 +14,8 @@ import type {
 	UnionToIntersection,
 } from "./types/helpers";
 import type {
+	DotNotationLeaf,
 	JoinKeys,
-	Primitive,
 	RecursiveDotNotation,
 	RemoveLastDot,
 } from "./types/object-to-dot-notation";
@@ -451,6 +451,8 @@ export type QueryTotal<Query extends SearchRequest> =
 			? number
 			: estypes.SearchTotalHits;
 
+type LeafFieldValue = DotNotationLeaf | ReadonlyArray<DotNotationLeaf>;
+
 type IsParentKeyALeaf<
 	K extends string,
 	E extends ElasticsearchIndexes,
@@ -459,7 +461,7 @@ type IsParentKeyALeaf<
 > = ParentKey extends string
 	? IsNever<TypeOfField<ParentKey, E, Index>> extends true
 		? false
-		: TypeOfField<ParentKey, E, Index> extends Primitive | Array<Primitive>
+		: TypeOfField<ParentKey, E, Index> extends LeafFieldValue
 			? true
 			: false
 	: false;

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -9,6 +9,15 @@ export type RArray<T> = readonly T[] | T[];
 export type ArrayItem<T> =
 	NonNullable<T> extends ReadonlyArray<infer Item> ? Item : NonNullable<T>;
 
+export type ArrayObjectItem<T> =
+	NonNullable<T> extends ReadonlyArray<infer Item>
+		? NonNullable<Item> extends object
+			? NonNullable<Item> extends Date | Function
+				? never
+				: NonNullable<Item>
+			: never
+		: never;
+
 export type MergeProperties<
 	A,
 	B,
@@ -208,12 +217,18 @@ export type Combinations<
 					: never
 		: never;
 
+type DeepPickValue<T, Path extends string> = [ArrayObjectItem<T>] extends [
+	never,
+]
+	? DeepPickOne<NonNullable<T>, Path>
+	: Array<DeepPickOne<ArrayObjectItem<T>, Path>>;
+
 type DeepPickOne<
 	T,
 	Path extends string,
 > = Path extends `${infer K}.${infer Rest}`
 	? K extends keyof T
-		? { [Q in K]: DeepPickOne<T[K], Rest> }
+		? { [Q in K]: DeepPickValue<T[K], Rest> }
 		: {}
 	: Path extends keyof T
 		? Pick<T, Path>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -6,6 +6,9 @@ export type PrettyArray<T> = Array<Prettify<T>>;
 
 export type RArray<T> = readonly T[] | T[];
 
+export type ArrayItem<T> =
+	NonNullable<T> extends ReadonlyArray<infer Item> ? Item : NonNullable<T>;
+
 export type MergeProperties<
 	A,
 	B,

--- a/src/types/object-to-dot-notation.ts
+++ b/src/types/object-to-dot-notation.ts
@@ -9,18 +9,20 @@ export type Primitive =
 	| null
 	| undefined;
 
+export type DotNotationLeaf = Primitive | Date | Function;
+
 export type JoinKeys<T, OnlyLeaf = false, Prefix extends string = ""> = {
-	[K in keyof T]: NonNullable<T[K]> extends Function
+	[K in keyof T]: NonNullable<T[K]> extends
+		| DotNotationLeaf
+		| ReadonlyArray<DotNotationLeaf>
 		? `${Prefix}${Extract<K, string>}`
-		: NonNullable<T[K]> extends Primitive | ReadonlyArray<Primitive> | Date
-			? `${Prefix}${Extract<K, string>}`
-			:
-					| (OnlyLeaf extends true ? never : `${Prefix}${Extract<K, string>}`)
-					| JoinKeys<
-							ArrayItem<T[K]>,
-							OnlyLeaf,
-							`${Prefix}${Extract<K, string>}.`
-					  >;
+		:
+				| (OnlyLeaf extends true ? never : `${Prefix}${Extract<K, string>}`)
+				| JoinKeys<
+						ArrayItem<T[K]>,
+						OnlyLeaf,
+						`${Prefix}${Extract<K, string>}.`
+				  >;
 }[keyof T];
 
 // Inverse steps

--- a/src/types/object-to-dot-notation.ts
+++ b/src/types/object-to-dot-notation.ts
@@ -1,3 +1,5 @@
+import type { ArrayItem } from "./helpers";
+
 export type Primitive =
 	| string
 	| number
@@ -8,13 +10,17 @@ export type Primitive =
 	| undefined;
 
 export type JoinKeys<T, OnlyLeaf = false, Prefix extends string = ""> = {
-	[K in keyof T]: T[K] extends Function
+	[K in keyof T]: NonNullable<T[K]> extends Function
 		? `${Prefix}${Extract<K, string>}`
-		: T[K] extends Primitive | Array<Primitive> | Date
+		: NonNullable<T[K]> extends Primitive | ReadonlyArray<Primitive> | Date
 			? `${Prefix}${Extract<K, string>}`
 			:
 					| (OnlyLeaf extends true ? never : `${Prefix}${Extract<K, string>}`)
-					| JoinKeys<T[K], OnlyLeaf, `${Prefix}${Extract<K, string>}.`>;
+					| JoinKeys<
+							ArrayItem<T[K]>,
+							OnlyLeaf,
+							`${Prefix}${Extract<K, string>}.`
+					  >;
 }[keyof T];
 
 // Inverse steps
@@ -24,7 +30,7 @@ export type RecursiveDotNotation<
 	Path extends string,
 > = Path extends `${infer Key}.${infer Rest}`
 	? Key extends keyof T
-		? RecursiveDotNotation<T[Key], Rest>
+		? RecursiveDotNotation<ArrayItem<T[Key]>, Rest>
 		: never
 	: Path extends keyof T
 		? T[Path]

--- a/src/types/output-fields.ts
+++ b/src/types/output-fields.ts
@@ -1,16 +1,12 @@
-import type { ArrayItem, UnionToIntersection } from "./helpers";
 import type {
-	Primitive,
+	ArrayItem,
+	ArrayObjectItem,
+	UnionToIntersection,
+} from "./helpers";
+import type {
 	RecursiveDotNotation,
 	RemoveLastDot,
 } from "./object-to-dot-notation";
-
-type ObjectArrayElement<T> =
-	NonNullable<T> extends ReadonlyArray<infer Item>
-		? NonNullable<Item> extends Primitive | Date | Function
-			? never
-			: NonNullable<Item>
-		: never;
 
 type ClosestObjectArrayPath<
 	Schema,
@@ -19,7 +15,7 @@ type ClosestObjectArrayPath<
 > = Field extends Parent
 	? never
 	: Parent extends string
-		? [ObjectArrayElement<RecursiveDotNotation<Schema, Parent>>] extends [never]
+		? [ArrayObjectItem<RecursiveDotNotation<Schema, Parent>>] extends [never]
 			? ClosestObjectArrayPath<Schema, Parent>
 			: Parent
 		: never;
@@ -30,11 +26,11 @@ type FieldObjectAtPath<
 	Value,
 > = Path extends `${infer Key}.${infer Rest}`
 	? Key extends keyof T
-		? [ObjectArrayElement<T[Key]>] extends [never]
+		? [ArrayObjectItem<T[Key]>] extends [never]
 			? { [K in Key]: FieldObjectAtPath<ArrayItem<T[Key]>, Rest, Value> }
 			: {
 					[K in Key]: Array<
-						FieldObjectAtPath<ObjectArrayElement<T[Key]>, Rest, Value>
+						FieldObjectAtPath<ArrayObjectItem<T[Key]>, Rest, Value>
 					>;
 				}
 		: {}

--- a/src/types/output-fields.ts
+++ b/src/types/output-fields.ts
@@ -1,0 +1,80 @@
+import type { ArrayItem, UnionToIntersection } from "./helpers";
+import type {
+	Primitive,
+	RecursiveDotNotation,
+	RemoveLastDot,
+} from "./object-to-dot-notation";
+
+type ObjectArrayElement<T> =
+	NonNullable<T> extends ReadonlyArray<infer Item>
+		? NonNullable<Item> extends Primitive | Date | Function
+			? never
+			: NonNullable<Item>
+		: never;
+
+type ClosestObjectArrayPath<
+	Schema,
+	Field extends string,
+	Parent = RemoveLastDot<Field>,
+> = Field extends Parent
+	? never
+	: Parent extends string
+		? [ObjectArrayElement<RecursiveDotNotation<Schema, Parent>>] extends [never]
+			? ClosestObjectArrayPath<Schema, Parent>
+			: Parent
+		: never;
+
+type FieldObjectAtPath<
+	T,
+	Path extends string,
+	Value,
+> = Path extends `${infer Key}.${infer Rest}`
+	? Key extends keyof T
+		? [ObjectArrayElement<T[Key]>] extends [never]
+			? { [K in Key]: FieldObjectAtPath<ArrayItem<T[Key]>, Rest, Value> }
+			: {
+					[K in Key]: Array<
+						FieldObjectAtPath<ObjectArrayElement<T[Key]>, Rest, Value>
+					>;
+				}
+		: {}
+	: Path extends keyof T
+		? { [K in Path]: Value }
+		: {};
+
+export type FieldsOutputForSchema<
+	Schema,
+	Field extends string,
+	Value,
+	Parent extends string = Extract<
+		ClosestObjectArrayPath<Schema, Field>,
+		string
+	>,
+> = [Parent] extends [never]
+	? Record<Field, Value>
+	: Field extends `${Parent}.${infer Rest}`
+		? {
+				[K in Parent]: Array<
+					FieldObjectAtPath<
+						ArrayItem<RecursiveDotNotation<Schema, Parent>>,
+						Rest,
+						Value
+					>
+				>;
+			}
+		: Record<Field, Value>;
+
+type ValueOfUnion<T, Key extends PropertyKey> =
+	T extends Record<Key, infer Value> ? Value : never;
+
+type MergeFieldValue<Value> = [Value] extends [ReadonlyArray<unknown>]
+	? [ArrayItem<Value>] extends [object]
+		? Array<UnionToIntersection<ArrayItem<Value>>>
+		: Value
+	: Value;
+
+export type MergeFieldsOutputEntries<Output> = {
+	[K in Output extends unknown ? keyof Output : never]: MergeFieldValue<
+		ValueOfUnion<Output, K>
+	>;
+};

--- a/tests/reproductions/407.test.ts
+++ b/tests/reproductions/407.test.ts
@@ -1,20 +1,48 @@
 import { expectTypeOf, test } from "bun:test";
-import { type TypedClient, typedEs } from "../../src";
+import { type PossibleFields, type TypedClient, typedEs } from "../../src";
 import type { TypedSearchResponse } from "../../src/override/search-response";
 
 type Indexes = {
 	products: {
 		bidule: Array<{ value: string; description: string }>;
+		readonly_bidule: ReadonlyArray<{ value: string }>;
+		created_at: Date[];
 	};
 };
 
 const client: TypedClient<Indexes> = undefined as any;
 
-test("407: fields output groups nested object array fields", () => {
+test("407: object array fields are possible leaf fields", () => {
+	expectTypeOf<PossibleFields<"products", Indexes, true>>().toEqualTypeOf<
+		| "bidule.value"
+		| "bidule.description"
+		| "readonly_bidule.value"
+		| "created_at"
+	>();
+});
+
+test("407: fields output groups one nested object array field", () => {
 	const query = typedEs(client, {
 		index: "products",
 		_source: false,
-		fields: ["bidule.value", "bidule.description"],
+		fields: ["bidule.value"],
+	});
+
+	type Output = TypedSearchResponse<typeof query, Indexes>;
+	type Hit = Output["hits"]["hits"][number];
+
+	expectTypeOf<Hit["fields"]>().toEqualTypeOf<{
+		bidule: Array<{
+			value: string[];
+		}>;
+	}>();
+});
+
+test("407: fields output merges nested object array fields", () => {
+	const query = typedEs(client, {
+		index: "products",
+		_source: false,
+		fields: ["bidule.value", "bidule.description", "readonly_bidule.value"],
 	});
 
 	type Output = TypedSearchResponse<typeof query, Indexes>;
@@ -24,6 +52,9 @@ test("407: fields output groups nested object array fields", () => {
 		bidule: Array<{
 			value: string[];
 			description: string[];
+		}>;
+		readonly_bidule: Array<{
+			value: string[];
 		}>;
 	}>();
 });

--- a/tests/reproductions/407.test.ts
+++ b/tests/reproductions/407.test.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf, test } from "bun:test";
+import { type TypedClient, typedEs } from "../../src";
+import type { TypedSearchResponse } from "../../src/override/search-response";
+
+type Indexes = {
+	products: {
+		bidule: Array<{ value: string; description: string }>;
+	};
+};
+
+const client: TypedClient<Indexes> = undefined as any;
+
+test("407: fields output groups nested object array fields", () => {
+	const query = typedEs(client, {
+		index: "products",
+		_source: false,
+		fields: ["bidule.value", "bidule.description"],
+	});
+
+	type Output = TypedSearchResponse<typeof query, Indexes>;
+	type Hit = Output["hits"]["hits"][number];
+
+	expectTypeOf<Hit["fields"]>().toEqualTypeOf<{
+		bidule: Array<{
+			value: string[];
+			description: string[];
+		}>;
+	}>();
+});


### PR DESCRIPTION
fix https://github.com/Vahor/typed-es/issues/407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type inference for `fields` and `_source` output when selecting fields within nested object arrays, ensuring proper type accuracy for complex nested structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->