### PR TITLE
fix: validate collapse field against index schema

### DIFF
--- a/.changeset/collapse-field-validation.md
+++ b/.changeset/collapse-field-validation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Validate `collapse` field against the index schema, including secondary collapse inside `inner_hits`.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -643,6 +643,7 @@ export type OverwrittenSearchRequestFields =
 	| "_source"
 	| "aggs"
 	| "aggregations"
+	| "collapse"
 	| "docvalue_fields"
 	| "script_fields"
 	| "fields"
@@ -670,6 +671,24 @@ type SearchFieldsRequest<Field extends string> = RArray<
 	  }
 >;
 
+type SearchInnerHitsWithCollapse<Field extends string> = Omit<
+	estypes.SearchInnerHits,
+	"collapse"
+> & {
+	collapse?: SearchCollapseRequest<Field>;
+};
+
+type SearchCollapseRequest<Field extends string> = Omit<
+	estypes.SearchFieldCollapse,
+	"field" | "inner_hits" | "collapse"
+> & {
+	field: Field;
+	inner_hits?:
+		| SearchInnerHitsWithCollapse<Field>
+		| RArray<SearchInnerHitsWithCollapse<Field>>;
+	collapse?: SearchCollapseRequest<Field>;
+};
+
 export type SearchRequest = Pick<
 	estypes.SearchRequest,
 	Exclude<OverwrittenSearchRequestFields, IssueWithReadonlyArray>
@@ -680,6 +699,7 @@ export type SearchRequest = Pick<
 	docvalue_fields?:
 		| estypes.SearchRequest["docvalue_fields"]
 		| SearchFieldsRequest<string>;
+	collapse?: SearchCollapseRequest<string>;
 };
 
 /**
@@ -744,11 +764,17 @@ type TypedSearchRequestForIndex<
 	docvalue_fields?: SearchFieldsRequest<
 		PossibleFieldsWithWildcards<Index, Indexes, true>
 	>;
+	collapse?: SearchCollapseRequest<PossibleFields<Index, Indexes, true, true>>;
 };
 
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<
 	estypes.SearchRequest,
-	"index" | "_source" | "fields" | "docvalue_fields" | IssueWithReadonlyArray
+	| "index"
+	| "_source"
+	| "fields"
+	| "docvalue_fields"
+	| "collapse"
+	| IssueWithReadonlyArray
 > &
 	(
 		| {

--- a/tests/reproductions/427.test.ts
+++ b/tests/reproductions/427.test.ts
@@ -41,3 +41,21 @@ test("427: valid collapse field keeps the response typed", () => {
 		name: string;
 	}>();
 });
+
+test("427: secondary collapse field is validated too", () => {
+	const query = typedEs(client, {
+		index: "demo",
+		_source: false,
+		collapse: {
+			field: "entity_id",
+			// @ts-expect-error `not_a_real_field` is not a valid field for index `demo`
+			inner_hits: {
+				name: "by_score",
+				collapse: {
+					field: "not_a_real_field",
+				},
+			},
+		},
+	});
+	expectTypeOf(query.collapse).not.toBeAny();
+});

--- a/tests/reproductions/427.test.ts
+++ b/tests/reproductions/427.test.ts
@@ -1,0 +1,43 @@
+import { expectTypeOf, test } from "bun:test";
+import { type TypedClient, typedEs } from "../../src";
+import type { TypedSearchResponse } from "../../src/override/search-response";
+
+type Indexes = {
+	demo: {
+		score: number;
+		entity_id: string;
+		name: string;
+	};
+};
+
+const client: TypedClient<Indexes> = undefined as any;
+
+test("427: collapse field is validated against the index schema", () => {
+	const query = typedEs(client, {
+		index: "demo",
+		_source: false,
+		collapse: {
+			// @ts-expect-error `not_a_real_field` is not a valid field for index `demo`
+			field: "not_a_real_field",
+		},
+	});
+	expectTypeOf(query.collapse).not.toBeAny();
+});
+
+test("427: valid collapse field keeps the response typed", () => {
+	const query = typedEs(client, {
+		index: "demo",
+		_source: ["name"],
+		collapse: {
+			field: "entity_id",
+			inner_hits: {
+				name: "by_name",
+			},
+		},
+	});
+
+	type Output = TypedSearchResponse<typeof query, Indexes>;
+	expectTypeOf<Output["hits"]["hits"][number]["_source"]>().toEqualTypeOf<{
+		name: string;
+	}>();
+});


### PR DESCRIPTION
Closes #427

## Summary

Validates `collapse.field` against the index schema, like `_source`, `fields`, and aggregation `field` options already do.

- `collapse` is now overridden in `TypedSearchRequest` with a `SearchCollapseRequest<Field>` type whose `field` is constrained to `PossibleFields<Index, Indexes, true, true>` (leaf fields with variants).
- Secondary collapse (`collapse.collapse` and `collapse.inner_hits[].collapse`) is validated too via a typed `inner_hits` override.
- `collapse` was added to `OverwrittenSearchRequestFields` so it is no longer widened from `estypes` and cannot be reassigned after creation (consistent with `_source`, `fields`, etc.).
- `msearch` inherits the validation through `TypedSearchRequest`.

## Tests

- `tests/reproductions/427.test.ts` covers:
  - invalid `collapse.field` produces a type error
  - valid `collapse.field` keeps the response typed
  - invalid secondary `collapse.field` inside `inner_hits` produces a type error

## Checklist

- [x] `bun typecheck` passes
- [x] `bun test` passes (359 pass, 9 skip)
- [x] `bunx @biomejs/biome check ./ --write` clean
- [x] Changeset added (patch)

Note: `bun run build` fails on `main` too (pre-existing tsdown/rolldown declaration export error, unrelated to this PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates `collapse.field` against the index schema, including nested collapse in `inner_hits`. This blocks invalid fields at compile time and keeps responses typed for search and msearch.

- **Bug Fixes**
  - Constrains `collapse.field` in `TypedSearchRequest` to valid leaf fields with variants.
  - Validates secondary collapse via typed `inner_hits` and `collapse` chaining.
  - Adds `collapse` to overwritten request fields to prevent `estypes` widening and reassignment.

<sup>Written for commit 3705566ca722954507c1f07c3960e3ff5e62b0d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vahor/typed-es/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

