### PR TITLE
fix: validate sort field names against index schema

### DIFF
--- a/.changeset/sort-field-validation.md
+++ b/.changeset/sort-field-validation.md
@@ -1,0 +1,5 @@
+---
+"@vahor/typed-es": patch
+---
+
+Validate sort field names against the index schema

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -691,33 +691,16 @@ type SearchCollapseRequest<Field extends string> = Omit<
 
 type SearchSortFieldValue = estypes.FieldSort | estypes.SortOrder;
 
-/**
- * Filters out non-literal string types (bare `string` and template literal types).
- * Template literal types like `score.${string}` are excluded because using them
- * as object keys behaves like a string index signature, accepting any field name.
- */
-type FilterToStringLiterals<T extends string> = T extends string
-	? string extends T
-		? never
-		: { [P in "__typed_es_not_a_sort_field__"]: 0 } extends {
-					[P in T]: 0;
-				}
-			? never
-			: T
-	: never;
-
 type SearchSortField<Field extends string> = {
-	[K in FilterToStringLiterals<Field>]: {
+	[K in Field]: {
 		[P in K]: SearchSortFieldValue;
 	};
-}[FilterToStringLiterals<Field>];
+}[Field];
 
 type SearchSortOptions<Field extends string> = estypes.SortOptionsKeys &
 	SearchSortField<Field>;
 
-type SearchSortRequest<Field extends string> =
-	| FilterToStringLiterals<Field>
-	| SearchSortOptions<Field>;
+type SearchSortRequest<Field extends string> = Field | SearchSortOptions<Field>;
 
 export type SearchRequest = Pick<
 	estypes.SearchRequest,
@@ -796,8 +779,8 @@ type TypedSearchRequestForIndex<
 	>;
 	collapse?: SearchCollapseRequest<PossibleFields<Index, Indexes, true, true>>;
 	sort?:
-		| SearchSortRequest<PossibleFields<Index, Indexes, true, true>>
-		| RArray<SearchSortRequest<PossibleFields<Index, Indexes, true, true>>>;
+		| SearchSortRequest<PossibleFields<Index, Indexes, true, false>>
+		| RArray<SearchSortRequest<PossibleFields<Index, Indexes, true, false>>>;
 };
 
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -689,6 +689,39 @@ type SearchCollapseRequest<Field extends string> = Omit<
 	collapse?: SearchCollapseRequest<Field>;
 };
 
+type SearchSortFieldValue =
+	| estypes.FieldSort
+	| estypes.SortOrder
+	| { order?: string };
+
+/**
+ * Filters out non-literal string types (bare `string` and template literal types).
+ * Template literal types like `score.${string}` are excluded because using them
+ * as object keys behaves like a string index signature, accepting any field name.
+ */
+type FilterToStringLiterals<T extends string> = T extends string
+	? string extends T
+		? never
+		: { [P in "__typed_es_not_a_sort_field__"]: 0 } extends {
+					[P in T]: 0;
+				}
+			? never
+			: T
+	: never;
+
+type SearchSortField<Field extends string> = {
+	[K in FilterToStringLiterals<Field>]: {
+		[P in K]: SearchSortFieldValue;
+	};
+}[FilterToStringLiterals<Field>];
+
+type SearchSortOptions<Field extends string> = estypes.SortOptionsKeys &
+	SearchSortField<Field>;
+
+type SearchSortRequest<Field extends string> =
+	| FilterToStringLiterals<Field>
+	| SearchSortOptions<Field>;
+
 export type SearchRequest = Pick<
 	estypes.SearchRequest,
 	Exclude<OverwrittenSearchRequestFields, IssueWithReadonlyArray>
@@ -765,6 +798,9 @@ type TypedSearchRequestForIndex<
 		PossibleFieldsWithWildcards<Index, Indexes, true>
 	>;
 	collapse?: SearchCollapseRequest<PossibleFields<Index, Indexes, true, true>>;
+	sort?:
+		| SearchSortRequest<PossibleFields<Index, Indexes, true, true>>
+		| RArray<SearchSortRequest<PossibleFields<Index, Indexes, true, true>>>;
 };
 
 export type TypedSearchRequest<Indexes extends ElasticsearchIndexes> = Omit<

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -689,10 +689,7 @@ type SearchCollapseRequest<Field extends string> = Omit<
 	collapse?: SearchCollapseRequest<Field>;
 };
 
-type SearchSortFieldValue =
-	| estypes.FieldSort
-	| estypes.SortOrder
-	| { order?: string };
+type SearchSortFieldValue = estypes.FieldSort | estypes.SortOrder;
 
 /**
  * Filters out non-literal string types (bare `string` and template literal types).

--- a/tests/reproductions/184.test.ts
+++ b/tests/reproductions/184.test.ts
@@ -15,8 +15,11 @@ test("type still works when sorting on _score with condition", async () => {
 		rest_total_hits_as_int: true,
 		sort:
 			order.field === "score"
-				? [{ score: { order: "asc" } }, { entity_id: { order: "asc" } }]
-				: [{ entity_id: { order: "asc" } }],
+				? ([
+						{ score: { order: "asc" } },
+						{ entity_id: { order: "asc" } },
+					] as const)
+				: ([{ entity_id: { order: "asc" } }] as const),
 	});
 
 	type Total = QueryTotal<typeof query>;

--- a/tests/reproductions/430.test.ts
+++ b/tests/reproductions/430.test.ts
@@ -38,3 +38,15 @@ test("430: valid sort field keeps the response typed", () => {
 		name: string;
 	}>();
 });
+
+test("430: nested sort fields are validated against the index schema", () => {
+	const query = typedEs(client, {
+		index: "demo",
+		_source: false,
+		sort: [
+			// @ts-expect-error `shipping_address.not_real` is not a valid field for index `demo`
+			{ "shipping_address.not_real": { order: "asc" } },
+		],
+	});
+	expectTypeOf(query.sort).not.toBeAny();
+});

--- a/tests/reproductions/430.test.ts
+++ b/tests/reproductions/430.test.ts
@@ -1,0 +1,40 @@
+import { expectTypeOf, test } from "bun:test";
+import { type TypedClient, typedEs } from "../../src";
+import type { TypedSearchResponse } from "../../src/override/search-response";
+
+type Indexes = {
+	demo: {
+		score: number;
+		entity_id: string;
+		name: string;
+	};
+};
+
+const client: TypedClient<Indexes> = undefined as any;
+
+test("430: sort field is validated against the index schema", () => {
+	const query = typedEs(client, {
+		index: "demo",
+		_source: false,
+		sort: [
+			// @ts-expect-error `not_a_real_field` is not a valid field for index `demo`
+			{ not_a_real_field: { order: "asc" } },
+		],
+	});
+	expectTypeOf(query.sort).not.toBeAny();
+});
+
+test("430: valid sort field keeps the response typed", () => {
+	const query = typedEs(client, {
+		index: "demo",
+		_source: ["name"],
+		sort: [{ entity_id: { order: "asc" } }],
+	});
+
+	type Output = TypedSearchResponse<typeof query, Indexes>;
+	type Hit = Output["hits"]["hits"][number];
+	expectTypeOf<Hit["sort"]>().not.toBeUndefined();
+	expectTypeOf<Output["hits"]["hits"][number]["_source"]>().toEqualTypeOf<{
+		name: string;
+	}>();
+});


### PR DESCRIPTION
Closes #430

## Summary

Validates sort field names against the index schema, like `collapse`, `_source`, `fields`, and aggregation `field` options already do.

- `sort` is now overridden in `TypedSearchRequest` with a `SearchSortRequest<Field>` type that restricts field names to `PossibleFields<Index, Indexes, true, false>` (leaf fields as plain literal paths).
- Nested fields like `shipping_address.street` are validated too — they resolve to plain literals (no variants), which avoids the template-literal-key-as-index-signature pitfall.
- Special sort keys (`_score`, `_doc`, `_geo_distance`, `_script`) remain allowed via `estypes.SortOptionsKeys`.
- `order` stays strictly typed as `"asc" | "desc"` (via `estypes.FieldSort` / `estypes.SortOrder`).
- `msearch` inherits the validation through `TypedSearchRequest`.

## Tests

- `tests/reproductions/430.test.ts` covers:
  - invalid top-level sort field produces a type error
  - invalid nested sort field produces a type error
  - valid sort field keeps the response typed (`hits[].sort` + `_source`)
- `tests/reproductions/184.test.ts` and `204.test.ts` keep passing (conditional sort and `hits[].sort` presence).

## Checklist

- [x] `bun typecheck` passes
- [x] `bun test` passes (362 pass, 9 skip)
- [x] `bunx @biomejs/biome check ./ --write` clean
- [x] Changeset added (patch)

Note: `bun run build` fails on `main` too (pre-existing tsdown/rolldown declaration export error, unrelated to this PR).